### PR TITLE
Feat: Add 'Enable WooCommerce Watermark' option

### DIFF
--- a/inc/Admin/Options.php
+++ b/inc/Admin/Options.php
@@ -178,6 +178,11 @@ class Options {
 						'label'   => esc_html__( 'Add Watermark on Page Load', 'watermark-my-images' ),
 						'summary' => esc_html__( 'This is useful for existing images.', 'watermark-my-images' ),
 					],
+					'woocommerce' => [
+						'control' => esc_attr( 'checkbox' ),
+						'label'   => esc_html__( 'Enable WooCommerce Watermarks', 'watermark-my-images' ),
+						'summary' => esc_html__( 'Allow WooCommerce serve watermark images.', 'watermark-my-images' ),
+					],
 					'logs'      => [
 						'control' => esc_attr( 'checkbox' ),
 						'label'   => esc_html__( 'Log errors for Failed Watermarks', 'watermark-my-images' ),

--- a/inc/Admin/Options.php
+++ b/inc/Admin/Options.php
@@ -168,12 +168,12 @@ class Options {
 			'image_options' => [
 				'heading'  => esc_html__( 'Image Options', 'watermark-my-images' ),
 				'controls' => [
-					'upload'    => [
+					'upload'      => [
 						'control' => esc_attr( 'checkbox' ),
 						'label'   => esc_html__( 'Add Watermark on Image Upload', 'watermark-my-images' ),
 						'summary' => esc_html__( 'This is useful for new images.', 'watermark-my-images' ),
 					],
-					'page_load' => [
+					'page_load'   => [
 						'control' => esc_attr( 'checkbox' ),
 						'label'   => esc_html__( 'Add Watermark on Page Load', 'watermark-my-images' ),
 						'summary' => esc_html__( 'This is useful for existing images.', 'watermark-my-images' ),
@@ -183,7 +183,7 @@ class Options {
 						'label'   => esc_html__( 'Enable WooCommerce Watermarks', 'watermark-my-images' ),
 						'summary' => esc_html__( 'Allow WooCommerce serve watermark images.', 'watermark-my-images' ),
 					],
-					'logs'      => [
+					'logs'        => [
 						'control' => esc_attr( 'checkbox' ),
 						'label'   => esc_html__( 'Log errors for Failed Watermarks', 'watermark-my-images' ),
 						'summary' => esc_html__( 'Enable this option to log errors.', 'watermark-my-images' ),

--- a/inc/Services/WooCommerce.php
+++ b/inc/Services/WooCommerce.php
@@ -43,6 +43,11 @@ class WooCommerce extends Service implements Registrable {
 	 * @return string
 	 */
 	public function add_watermark_on_get_image( $image_html, $product, $size, $attr, $placeholder ): string {
+		// Bail out, if not enabled in Options.
+		if ( ! wmig_get_settings( 'woocommerce' ) ) {
+			return $image_html;
+		}
+
 		$this->image_id  = $product->get_image_id();
 		$image_watermark = get_post_meta( $this->image_id, 'watermark_my_images', true );
 

--- a/inc/Services/WooCommerce.php
+++ b/inc/Services/WooCommerce.php
@@ -24,6 +24,35 @@ class WooCommerce extends Service implements Registrable {
 	 */
 	public function register(): void {
 		add_filter( 'woocommerce_product_get_image', [ $this, 'add_watermark_on_get_image' ], 10, 5 );
+		add_filter( 'woocommerce_single_product_image_thumbnail_html', [ $this, 'add_watermark_to_product_gallery_image' ], 10, 2 );
+	}
+
+	/**
+	 * Add Watermark to Product Gallery Image.
+	 *
+	 * This method is used to add watermark to the
+	 * product gallery image.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string $html    HTML of the product gallery image.
+	 * @param int    $post_id Post ID of the product.
+	 *
+	 * @return string
+	 */
+	public function add_watermark_to_product_gallery_image( $html, $post_id ) {
+		// Bail out, if not enabled in Options.
+		if ( ! wmig_get_settings( 'woocommerce' ) ) {
+			return $html;
+		}
+
+		$image_watermark = get_post_meta( absint( $post_id ), 'watermark_my_images', true );
+
+		if ( ! empty( $image_watermark['rel'] ) && file_exists( $image_watermark['abs'] ) ) {
+			return str_replace( wp_get_attachment_url( $post_id ), esc_url( $image_watermark['rel'] ), $html );
+		}
+
+		return $html;
 	}
 
 	/**

--- a/tests/Admin/OptionsTest.php
+++ b/tests/Admin/OptionsTest.php
@@ -78,7 +78,7 @@ class OptionsTest extends TestCase {
 		\WP_Mock::userFunction(
 			'esc_html__',
 			[
-				'times'  => 20,
+				'times'  => 22,
 				'return' => function ( $text, $domain = 'watermark-my-images' ) {
 					return $text;
 				},
@@ -88,7 +88,7 @@ class OptionsTest extends TestCase {
 		\WP_Mock::userFunction(
 			'esc_attr',
 			[
-				'times'  => 9,
+				'times'  => 10,
 				'return' => function ( $text, $domain = 'watermark-my-images' ) {
 					return $text;
 				},
@@ -163,6 +163,11 @@ class OptionsTest extends TestCase {
 							'control' => 'checkbox',
 							'label'   => 'Add Watermark on Page Load',
 							'summary' => 'This is useful for existing images.',
+						],
+						'woocommerce' => [
+							'control' => 'checkbox',
+							'label'   => 'Enable WooCommerce Watermarks',
+							'summary' => 'Allow WooCommerce serve watermark images.',
 						],
 						'logs'      => [
 							'control' => 'checkbox',

--- a/tests/Admin/OptionsTest.php
+++ b/tests/Admin/OptionsTest.php
@@ -154,12 +154,12 @@ class OptionsTest extends TestCase {
 				'image_options' => [
 					'heading'  => 'Image Options',
 					'controls' => [
-						'upload'    => [
+						'upload'      => [
 							'control' => 'checkbox',
 							'label'   => 'Add Watermark on Image Upload',
 							'summary' => 'This is useful for new images.',
 						],
-						'page_load' => [
+						'page_load'   => [
 							'control' => 'checkbox',
 							'label'   => 'Add Watermark on Page Load',
 							'summary' => 'This is useful for existing images.',
@@ -169,7 +169,7 @@ class OptionsTest extends TestCase {
 							'label'   => 'Enable WooCommerce Watermarks',
 							'summary' => 'Allow WooCommerce serve watermark images.',
 						],
-						'logs'      => [
+						'logs'        => [
 							'control' => 'checkbox',
 							'label'   => 'Log errors for Failed Watermarks',
 							'summary' => 'Enable this option to log errors.',

--- a/tests/Core/ContainerTest.php
+++ b/tests/Core/ContainerTest.php
@@ -228,6 +228,16 @@ class ContainerTest extends TestCase {
 			5
 		);
 
+		\WP_Mock::expectFilterAdded(
+			'woocommerce_single_product_image_thumbnail_html',
+			[
+				Service::$instances[ WooCommerce::class ],
+				'add_watermark_to_product_gallery_image'
+			],
+			10,
+			2
+		);
+
 		$container->register();
 
 		$this->assertConditionsMet();

--- a/tests/Core/ContainerTest.php
+++ b/tests/Core/ContainerTest.php
@@ -232,7 +232,7 @@ class ContainerTest extends TestCase {
 			'woocommerce_single_product_image_thumbnail_html',
 			[
 				Service::$instances[ WooCommerce::class ],
-				'add_watermark_to_product_gallery_image'
+				'add_watermark_to_product_gallery_image',
 			],
 			10,
 			2

--- a/tests/Services/AdminTest.php
+++ b/tests/Services/AdminTest.php
@@ -52,7 +52,7 @@ class AdminTest extends TestCase {
 		\WP_Mock::userFunction(
 			'esc_html__',
 			[
-				'times'  => 75,
+				'times'  => 81,
 				'return' => function ( $text, $domain = 'watermark-my-images' ) {
 					return $text;
 				},
@@ -62,7 +62,7 @@ class AdminTest extends TestCase {
 		\WP_Mock::userFunction(
 			'esc_attr',
 			[
-				'times'  => 27,
+				'times'  => 30,
 				'return' => function ( $text ) {
 					return $text;
 				},
@@ -99,7 +99,7 @@ class AdminTest extends TestCase {
 		\WP_Mock::userFunction(
 			'esc_html__',
 			[
-				'times'  => 75,
+				'times'  => 81,
 				'return' => function ( $text, $domain = 'watermark-my-images' ) {
 					return $text;
 				},
@@ -109,7 +109,7 @@ class AdminTest extends TestCase {
 		\WP_Mock::userFunction(
 			'esc_attr',
 			[
-				'times'  => 27,
+				'times'  => 30,
 				'return' => function ( $text ) {
 					return $text;
 				},
@@ -135,7 +135,7 @@ class AdminTest extends TestCase {
 		\WP_Mock::userFunction(
 			'esc_html__',
 			[
-				'times'  => 75,
+				'times'  => 81,
 				'return' => function ( $text, $domain = 'watermark-my-images' ) {
 					return $text;
 				},
@@ -145,7 +145,7 @@ class AdminTest extends TestCase {
 		\WP_Mock::userFunction(
 			'esc_attr',
 			[
-				'times'  => 27,
+				'times'  => 30,
 				'return' => function ( $text ) {
 					return $text;
 				},
@@ -188,7 +188,7 @@ class AdminTest extends TestCase {
 		\WP_Mock::userFunction(
 			'esc_html__',
 			[
-				'times'  => 125,
+				'times'  => 135,
 				'return' => function ( $text, $domain = 'watermark-my-images' ) {
 					return $text;
 				},
@@ -198,7 +198,7 @@ class AdminTest extends TestCase {
 		\WP_Mock::userFunction(
 			'esc_attr',
 			[
-				'times'  => 45,
+				'times'  => 50,
 				'return' => function ( $text ) {
 					return $text;
 				},
@@ -228,7 +228,7 @@ class AdminTest extends TestCase {
 		\WP_Mock::userFunction(
 			'wp_unslash',
 			[
-				'times'  => 10,
+				'times'  => 11,
 				'return' => function ( $text ) {
 					return $text;
 				},
@@ -238,7 +238,7 @@ class AdminTest extends TestCase {
 		\WP_Mock::userFunction(
 			'sanitize_text_field',
 			[
-				'times'  => 10,
+				'times'  => 11,
 				'return' => function ( $text ) {
 					return $text;
 				},
@@ -259,6 +259,7 @@ class AdminTest extends TestCase {
 					'bg_color'   => '',
 					'tx_opacity' => '',
 					'bg_opacity' => '',
+					'woocommerce' => '',
 				]
 			)
 			->andReturn( true );
@@ -272,7 +273,7 @@ class AdminTest extends TestCase {
 		\WP_Mock::userFunction(
 			'esc_html__',
 			[
-				'times'  => 125,
+				'times'  => 135,
 				'return' => function ( $text, $domain = 'watermark-my-images' ) {
 					return $text;
 				},
@@ -282,7 +283,7 @@ class AdminTest extends TestCase {
 		\WP_Mock::userFunction(
 			'esc_attr',
 			[
-				'times'  => 45,
+				'times'  => 50,
 				'return' => function ( $text ) {
 					return $text;
 				},
@@ -321,7 +322,7 @@ class AdminTest extends TestCase {
 		\WP_Mock::userFunction(
 			'wp_unslash',
 			[
-				'times'  => 10,
+				'times'  => 11,
 				'return' => function ( $text ) {
 					return $text;
 				},
@@ -331,7 +332,7 @@ class AdminTest extends TestCase {
 		\WP_Mock::userFunction(
 			'sanitize_text_field',
 			[
-				'times'  => 10,
+				'times'  => 11,
 				'return' => function ( $text ) {
 					return $text;
 				},
@@ -352,6 +353,7 @@ class AdminTest extends TestCase {
 					'bg_color'   => '',
 					'tx_opacity' => '',
 					'bg_opacity' => '',
+					'woocommerce' => '',
 				]
 			)
 			->andReturn( true );

--- a/tests/Services/AdminTest.php
+++ b/tests/Services/AdminTest.php
@@ -250,15 +250,15 @@ class AdminTest extends TestCase {
 			->with(
 				'watermark_my_images',
 				[
-					'upload'     => '',
-					'page_load'  => '',
-					'logs'       => '',
-					'label'      => '',
-					'size'       => '',
-					'tx_color'   => '',
-					'bg_color'   => '',
-					'tx_opacity' => '',
-					'bg_opacity' => '',
+					'upload'      => '',
+					'page_load'   => '',
+					'logs'        => '',
+					'label'       => '',
+					'size'        => '',
+					'tx_color'    => '',
+					'bg_color'    => '',
+					'tx_opacity'  => '',
+					'bg_opacity'  => '',
 					'woocommerce' => '',
 				]
 			)
@@ -344,15 +344,15 @@ class AdminTest extends TestCase {
 			->with(
 				'watermark_my_images',
 				[
-					'upload'     => true,
-					'page_load'  => '',
-					'logs'       => '',
-					'label'      => 'WATERMARK',
-					'size'       => 60,
-					'tx_color'   => '',
-					'bg_color'   => '',
-					'tx_opacity' => '',
-					'bg_opacity' => '',
+					'upload'      => true,
+					'page_load'   => '',
+					'logs'        => '',
+					'label'       => 'WATERMARK',
+					'size'        => 60,
+					'tx_color'    => '',
+					'bg_color'    => '',
+					'tx_opacity'  => '',
+					'bg_opacity'  => '',
 					'woocommerce' => '',
 				]
 			)

--- a/tests/Services/WooCommerceTest.php
+++ b/tests/Services/WooCommerceTest.php
@@ -45,10 +45,19 @@ class WooCommerceTest extends TestCase {
 		$product = Mockery::mock( \WC_Product::class )->makePartial();
 		$product->shouldAllowMockingProtectedMethods();
 
+		\WP_Mock::userFunction( 'get_option' )
+			->once()
+			->with( 'watermark_my_images', [] )
+			->andReturn(
+				[
+					'upload' => false,
+				]
+			);
+
 		$product->shouldReceive( 'get_image_id' )
 			->andReturn( 1 );
 
-		\WP_Mock::userFunction( 'get_post_meta' )
+		/*\WP_Mock::userFunction( 'get_post_meta' )
 			->once()
 			->with( 1, 'watermark_my_images', true )
 			->andReturn(
@@ -56,7 +65,7 @@ class WooCommerceTest extends TestCase {
 					'abs' => __DIR__ . '/sample.png',
 					'rel' => 'https://example.com/wp-content/uploads/2024/10/sample-watermark-my-images.jpg',
 				]
-			);
+			);*/
 
 		$image = $this->woocommerce->add_watermark_on_get_image(
 			'<img src="">',
@@ -72,6 +81,15 @@ class WooCommerceTest extends TestCase {
 	public function test_add_watermark_on_get_image_passes() {
 		$product = Mockery::mock( \WC_Product::class )->makePartial();
 		$product->shouldAllowMockingProtectedMethods();
+
+		\WP_Mock::userFunction( 'get_option' )
+			->once()
+			->with( 'watermark_my_images', [] )
+			->andReturn(
+				[
+					'woocommerce' => true,
+				]
+			);
 
 		$product->shouldReceive( 'get_image_id' )
 			->once()

--- a/tests/Services/WooCommerceTest.php
+++ b/tests/Services/WooCommerceTest.php
@@ -36,6 +36,7 @@ class WooCommerceTest extends TestCase {
 
 	public function test_register() {
 		\WP_Mock::expectFilterAdded( 'woocommerce_product_get_image', [ $this->woocommerce, 'add_watermark_on_get_image' ], 10, 5 );
+		\WP_Mock::expectFilterAdded( 'woocommerce_single_product_image_thumbnail_html', [ $this->woocommerce, 'add_watermark_to_product_gallery_image' ], 10, 2 );
 
 		$this->woocommerce->register();
 

--- a/tests/Services/WooCommerceTest.php
+++ b/tests/Services/WooCommerceTest.php
@@ -15,6 +15,7 @@ use WatermarkMyImages\Services\WooCommerce;
  * @covers \WatermarkMyImages\Services\WooCommerce::add_watermark_on_get_image
  * @covers \WatermarkMyImages\Services\WooCommerce::get_image_html
  * @covers \WatermarkMyImages\Engine\Watermarker::__construct
+ * @covers wmig_get_settings
  */
 class WooCommerceTest extends TestCase {
 	public WooCommerce $woocommerce;


### PR DESCRIPTION
This PR resolves the [issue](https://github.com/badasswp/watermark-my-images/issues/3).

## Description / Background Context

This PR introduces a new feature in the plugin options page - **Enable WooCommerce Watermark**.

<img width="461" alt="Screenshot 2024-11-19 at 12 06 19" src="https://github.com/user-attachments/assets/7eef0272-49dd-4436-aedf-4d29ed32f3e2">
 
## Testing Instructions

1. Pull PR to local.
2. Go to plugin options page.
3. Locate new WooCommerce option.
4. Observe that all controls work correctly as before and there are no regressions.