### PR TITLE
Refactor: Pass Service Instances via DI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # watermark-my-images
 Insert Watermarks into your WP images.
 
+[![Coverage Status](https://coveralls.io/repos/github/badasswp/watermark-my-images/badge.svg?branch=master)](https://coveralls.io/github/badasswp/watermark-my-images?branch=master)
+
 <img width="1018" alt="screenshot-1" src="https://github.com/user-attachments/assets/2f8218c9-2dd1-4d6f-9998-f7c84c5b070a">
 
 ## Download

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     "phpunit/phpcov": "^8.2",
     "phpstan/phpstan": "^1.10",
     "szepeviktor/phpstan-wordpress": "^1.3",
-    "phpstan/extension-installer": "^1.3"
+    "phpstan/extension-installer": "^1.3",
+    "dg/bypass-finals": "^1.9"
   },
   "config": {
     "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
     "lint": "vendor/bin/phpcs -v",
     "lint:fix": "vendor/bin/phpcbf -v",
     "test": "vendor/bin/phpunit --testdox",
-    "analyse": "vendor/bin/phpstan analyse --memory-limit=2048M"
+    "analyse": "vendor/bin/phpstan analyse --memory-limit=2048M",
+    "coverage": "XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-cobertura cobertura.xml && coveralls --repo-token=O1AV3K3l9gSHKgeI4ic1Tn2PHweT232MN --file=cobertura.xml"
   }
 }

--- a/inc/Abstracts/Entity.php
+++ b/inc/Abstracts/Entity.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Entity Abstraction.
+ *
+ * Establish base methods for different entities
+ * such as Image, Text and so on.
+ *
+ * @package WatermarkMyImages
+ */
+
+namespace WatermarkMyImages\Abstracts;
+
+use Imagine\Gd\Imagine;
+use Imagine\Image\Palette\RGB;
+
+abstract class Entity {
+	/**
+	 * Get RGB.
+	 *
+	 * @since TBD
+	 *
+	 * @param RGB $rgb
+	 * @return RGB
+	 */
+	protected function get_rgb( RGB $rgb ): RGB {
+		return $rgb;
+	}
+
+	/**
+	 * Get Imagine.
+	 *
+	 * @since TBD
+	 *
+	 * @param Imagine $imagine
+	 * @return Imagine
+	 */
+	protected function get_imagine( Imagine $imagine ): Imagine {
+		return $imagine;
+	}
+}

--- a/inc/Abstracts/Service.php
+++ b/inc/Abstracts/Service.php
@@ -21,7 +21,7 @@ abstract class Service implements Registrable {
 	 *
 	 * @var array
 	 */
-	protected static array $instances;
+	public static array $instances;
 
 	/**
 	 * Watermarker Instance.

--- a/inc/Admin/Form.php
+++ b/inc/Admin/Form.php
@@ -18,7 +18,7 @@ class Form {
 	 *
 	 * @var mixed[]
 	 */
-	private array $options;
+	protected array $options;
 
 	/**
 	 * Set up Constructor.

--- a/inc/Engine/Image.php
+++ b/inc/Engine/Image.php
@@ -13,28 +13,9 @@ namespace WatermarkMyImages\Engine;
 use Imagine\Gd\Imagine;
 use Imagine\Image\ImageInterface as Image_Object;
 
-class Image {
-	/**
-	 * Imagine object.
-	 *
-	 * This object is an instance of the
-	 * Imagine class.
-	 *
-	 * @since 1.0.5
-	 *
-	 * @var Imagine
-	 */
-	protected $imagine;
+use WatermarkMyImages\Abstracts\Entity;
 
-	/**
-	 * Set up.
-	 *
-	 * @since 1.0.5
-	 */
-	public function __construct() {
-		$this->imagine = new Imagine();
-	}
-
+class Image extends Entity {
 	/**
 	 * Get Image Resource.
 	 *
@@ -44,7 +25,7 @@ class Image {
 	 */
 	public function get_image(): Image_Object {
 		try {
-			return $this->imagine->open( Watermarker::$file );
+			return $this->get_imagine( new Imagine() )->open( Watermarker::$file );
 		} catch ( \Exception $e ) {
 			throw new \Exception(
 				sprintf(

--- a/inc/Engine/Text.php
+++ b/inc/Engine/Text.php
@@ -17,7 +17,9 @@ use Imagine\Gd\Imagine;
 use Imagine\Image\Point;
 use Imagine\Image\Palette\RGB;
 
-class Text {
+use WatermarkMyImages\Abstracts\Entity;
+
+class Text extends Entity {
 	/**
 	 * Text Args.
 	 *
@@ -104,7 +106,7 @@ class Text {
 	 */
 	protected function get_font(): Font {
 		try {
-			$tx_color = ( new RGB() )->color( $this->get_option( 'tx_color' ), (int) $this->get_option( 'tx_opacity' ) );
+			$tx_color = $this->get_rgb( new RGB() )->color( $this->get_option( 'tx_color' ), (int) $this->get_option( 'tx_opacity' ) );
 		} catch ( \Exception $e ) {
 			throw new \Exception(
 				sprintf(
@@ -135,7 +137,7 @@ class Text {
 	 */
 	public function get_text(): Image {
 		try {
-			$bg_color = ( new RGB() )->color( $this->get_option( 'bg_color' ), (int) $this->get_option( 'bg_opacity' ) );
+			$bg_color = $this->get_rgb( new RGB() )->color( $this->get_option( 'bg_color' ), (int) $this->get_option( 'bg_opacity' ) );
 		} catch ( \Exception $e ) {
 			throw new \Exception(
 				sprintf(
@@ -147,7 +149,7 @@ class Text {
 		}
 
 		try {
-			$text_box = ( new Imagine() )->create(
+			$text_box = $this->get_imagine( new Imagine() )->create(
 				new Box(
 					$this->get_text_length(),
 					$this->get_option( 'size' )

--- a/inc/Engine/Text.php
+++ b/inc/Engine/Text.php
@@ -150,10 +150,7 @@ class Text extends Entity {
 
 		try {
 			$text_box = $this->get_imagine( new Imagine() )->create(
-				new Box(
-					$this->get_text_length(),
-					$this->get_option( 'size' )
-				),
+				$this->get_text_box(),
 				$bg_color
 			);
 		} catch ( \Exception $e ) {
@@ -183,6 +180,20 @@ class Text extends Entity {
 		}
 
 		return $text_box;
+	}
+
+	/**
+	 * Get Text Box.
+	 *
+	 * @since TBD
+	 *
+	 * @return Box
+	 */
+	protected function get_text_box(): Box {
+		return new Box(
+			$this->get_text_length(),
+			$this->get_option( 'size' )
+		);
 	}
 
 	/**

--- a/inc/Services/Admin.php
+++ b/inc/Services/Admin.php
@@ -126,6 +126,13 @@ class Admin extends Service implements Registrable {
 	 * @return void
 	 */
 	public function register_options_styles(): void {
+		$screen = get_current_screen();
+
+		// Bail out, if not plugin Admin page.
+		if ( ! is_object( $screen ) || 'toplevel_page_watermark-my-images' !== $screen->id ) {
+			return;
+		}
+
 		wp_enqueue_style(
 			Options::get_page_slug(),
 			plugins_url( 'watermark-my-images/styles.css' ),

--- a/tests/Admin/FormTest.php
+++ b/tests/Admin/FormTest.php
@@ -413,7 +413,8 @@ class FormTest extends TestCase {
 	}
 
 	public function test_get_form_notice_bails_out_if_button_name_is_not_set() {
-		$_POST['nonce_name'] = 'nonce_action\/';
+		$_POST['button_name'] = null;
+		$_POST['nonce_name']  = 'nonce_action\/';
 
 		\WP_Mock::userFunction( 'wp_unslash' )
 			->andReturnUsing(

--- a/tests/Admin/FormTest.php
+++ b/tests/Admin/FormTest.php
@@ -16,6 +16,9 @@ use WatermarkMyImages\Admin\Form;
  * @covers \WatermarkMyImages\Admin\Form::get_form_group_body
  * @covers \WatermarkMyImages\Admin\Form::get_setting
  * @covers \WatermarkMyImages\Admin\Form::get_form_control
+ * @covers \WatermarkMyImages\Admin\Form::get_text_control
+ * @covers \WatermarkMyImages\Admin\Form::get_checkbox_control
+ * @covers \WatermarkMyImages\Admin\Form::get_select_control
  */
 class FormTest extends TestCase {
 	public Form $form;
@@ -338,6 +341,34 @@ class FormTest extends TestCase {
 				type="checkbox"
 				checked
 			/>',
+			$control
+		);
+	}
+
+	public function test_get_select_control() {
+		$this->form->shouldReceive( 'get_setting' )
+			->times( 4 )->with( 'select_name' )->andReturn( 'selected_option' );
+
+		$control = $this->form->get_select_control(
+			[
+				'control'     => 'select',
+				'placeholder' => 'Select Placeholder',
+				'label'       => 'Select Label',
+				'summary'     => 'Select Summary',
+				'options'     => [
+					'not_selected_option_1' => 'Not Selected Option 1',
+					'not_selected_option_2' => 'Not Selected Option 2',
+					'selected_option'       => 'Selected Option',
+					'not_selected_option_3' => 'Not Selected Option 3',
+				]
+			],
+			'select_name'
+		);
+
+		$this->assertSame(
+			'<select name="select_name">
+				<option value="not_selected_option_1" >Not Selected Option 1</option><option value="not_selected_option_2" >Not Selected Option 2</option><option value="selected_option" selected>Selected Option</option><option value="not_selected_option_3" >Not Selected Option 3</option>
+			</select>',
 			$control
 		);
 	}

--- a/tests/Admin/FormTest.php
+++ b/tests/Admin/FormTest.php
@@ -14,6 +14,7 @@ use WatermarkMyImages\Admin\Form;
  * @covers \WatermarkMyImages\Admin\Form::get_form_main
  * @covers \WatermarkMyImages\Admin\Form::get_form_group
  * @covers \WatermarkMyImages\Admin\Form::get_form_group_body
+ * @covers \WatermarkMyImages\Admin\Form::get_setting
  */
 class FormTest extends TestCase {
 	public Form $form;
@@ -33,6 +34,8 @@ class FormTest extends TestCase {
 				'page'   => [
 					'title'   => 'Plugin Title',
 					'summary' => 'Plugin Summary',
+					'slug'    => 'plugin-slug',
+					'option'  => 'plugin_option',
 				],
 				'fields' => [
 					'form_group_1',
@@ -195,5 +198,21 @@ class FormTest extends TestCase {
 				</p>',
 			$form_group_body
 		);
+	}
+
+	public function test_get_setting() {
+		\WP_Mock::userFunction( 'get_option' )
+			->with( 'plugin_option', [] )
+			->andReturn(
+				[
+					'option_1' => 'Option 1',
+					'option_2' => 'Option 2',
+					'option_3' => 'Option 3',
+				]
+			);
+
+		$this->assertSame( 'Option 1', $this->form->get_setting( 'option_1' ) );
+		$this->assertSame( 'Option 2', $this->form->get_setting( 'option_2' ) );
+		$this->assertSame( 'Option 3', $this->form->get_setting( 'option_3' ) );
 	}
 }

--- a/tests/Admin/FormTest.php
+++ b/tests/Admin/FormTest.php
@@ -7,6 +7,7 @@ use WP_Mock\Tools\TestCase;
 use WatermarkMyImages\Admin\Form;
 
 /**
+ * @covers \WatermarkMyImages\Admin\Form::__construct
  * @covers \WatermarkMyImages\Admin\Form::get_options
  * @covers \WatermarkMyImages\Admin\Form::get_form
  */

--- a/tests/Admin/FormTest.php
+++ b/tests/Admin/FormTest.php
@@ -13,6 +13,7 @@ use WatermarkMyImages\Admin\Form;
  * @covers \WatermarkMyImages\Admin\Form::get_form_action
  * @covers \WatermarkMyImages\Admin\Form::get_form_main
  * @covers \WatermarkMyImages\Admin\Form::get_form_group
+ * @covers \WatermarkMyImages\Admin\Form::get_form_group_body
  */
 class FormTest extends TestCase {
 	public Form $form;
@@ -158,6 +159,41 @@ class FormTest extends TestCase {
 		$this->assertSame(
 			'<div class="badasswp-form-group"><div class="badasswp-form-group-heading">Form Heading</div><div class="badasswp-form-group-body">Form Group Body</div></div>',
 			$form_group
+		);
+	}
+
+	public function test_get_form_group_body() {
+		$this->form->shouldReceive( 'get_form_control' )
+			->times( 1 )
+			->with(
+				[
+					'control'     => 'text',
+					'placeholder' => 'Placeholder',
+					'label'       => 'Label',
+					'summary'     => 'Summary',
+				],
+				'name'
+			)
+			->andReturn( 'Form Control' );
+
+		$form_group_body = $this->form->get_form_group_body(
+			[
+				'name' => [
+					'control'     => 'text',
+					'placeholder' => 'Placeholder',
+					'label'       => 'Label',
+					'summary'     => 'Summary',
+				],
+			]
+		);
+
+		$this->assertSame(
+			'<p class="badasswp-form-group-block">
+					<label>Label</label>
+					Form Control
+					<em>Summary</em>
+				</p>',
+			$form_group_body
 		);
 	}
 }

--- a/tests/Admin/FormTest.php
+++ b/tests/Admin/FormTest.php
@@ -12,6 +12,7 @@ use WatermarkMyImages\Admin\Form;
  * @covers \WatermarkMyImages\Admin\Form::get_form
  * @covers \WatermarkMyImages\Admin\Form::get_form_action
  * @covers \WatermarkMyImages\Admin\Form::get_form_main
+ * @covers \WatermarkMyImages\Admin\Form::get_form_group
  */
 class FormTest extends TestCase {
 	public Form $form;
@@ -139,6 +140,24 @@ class FormTest extends TestCase {
 		$this->assertSame(
 			'<section>form_group_1</section><section>form_group_2</section><section>form_group_3</section>',
 			$form_main
+		);
+	}
+
+	public function test_get_form_group() {
+		$this->form->shouldReceive( 'get_form_group_body' )
+			->once()
+			->andReturn( 'Form Group Body' );
+
+		$form_group = $this->form->get_form_group(
+			[
+				'heading' => 'Form Heading',
+				'controls' => []
+			]
+		);
+
+		$this->assertSame(
+			'<div class="badasswp-form-group"><div class="badasswp-form-group-heading">Form Heading</div><div class="badasswp-form-group-body">Form Group Body</div></div>',
+			$form_group
 		);
 	}
 }

--- a/tests/Admin/FormTest.php
+++ b/tests/Admin/FormTest.php
@@ -150,8 +150,8 @@ class FormTest extends TestCase {
 
 		$form_group = $this->form->get_form_group(
 			[
-				'heading' => 'Form Heading',
-				'controls' => []
+				'heading'  => 'Form Heading',
+				'controls' => [],
 			]
 		);
 

--- a/tests/Admin/FormTest.php
+++ b/tests/Admin/FormTest.php
@@ -8,6 +8,7 @@ use WatermarkMyImages\Admin\Form;
 
 /**
  * @covers \WatermarkMyImages\Admin\Form::get_options
+ * @covers \WatermarkMyImages\Admin\Form::get_form
  */
 class FormTest extends TestCase {
 	public Form $form;
@@ -52,6 +53,34 @@ class FormTest extends TestCase {
 				'summary' => 'Plugin Summary',
 				'form'    => 'Plugin Form',
 			]
+		);
+	}
+
+	public function test_get_form() {
+		$form = Mockery::mock( Form::class )->makePartial();
+		$form->shouldAllowMockingProtectedMethods();
+
+		$form->shouldReceive( 'get_form_action' )
+			->andReturn( 'https://example.com' );
+
+		$form->shouldReceive( 'get_form_notice' )
+			->andReturn( 'Form Notice' );
+
+		$form->shouldReceive( 'get_form_main' )
+			->andReturn( 'Form Main' );
+
+		$form->shouldReceive( 'get_form_submit' )
+			->andReturn( 'Form Submit' );
+
+		$plugin_form = $form->get_form();
+
+		$this->assertSame(
+			'<form class="badasswp-form" method="POST" action="https://example.com">
+				Form Notice
+				<div class="badasswp-form-main">Form Main</div>
+				<div class="badasswp-form-submit">Form Submit</div>
+			</form>',
+			$plugin_form
 		);
 	}
 }

--- a/tests/Admin/FormTest.php
+++ b/tests/Admin/FormTest.php
@@ -297,4 +297,24 @@ class FormTest extends TestCase {
 
 		$this->assertSame( 'Checkbox Control', $control );
 	}
+
+	public function test_get_text_control() {
+		$this->form->shouldReceive( 'get_setting' )
+			->times( 1 )->with( 'text_name' )->andReturn( 'Text Name' );
+
+		$control = $this->form->get_text_control(
+			[
+				'control'     => 'text',
+				'placeholder' => 'Text Placeholder',
+				'label'       => 'Text Label',
+				'summary'     => 'Text Summary',
+			],
+			'text_name'
+		);
+
+		$this->assertSame(
+			'<input type="text" placeholder="Text Placeholder" value="Text Name" name="text_name"/>',
+			$control
+		);
+	}
 }

--- a/tests/Admin/FormTest.php
+++ b/tests/Admin/FormTest.php
@@ -15,6 +15,7 @@ use WatermarkMyImages\Admin\Form;
  * @covers \WatermarkMyImages\Admin\Form::get_form_group
  * @covers \WatermarkMyImages\Admin\Form::get_form_group_body
  * @covers \WatermarkMyImages\Admin\Form::get_setting
+ * @covers \WatermarkMyImages\Admin\Form::get_form_control
  */
 class FormTest extends TestCase {
 	public Form $form;
@@ -214,5 +215,86 @@ class FormTest extends TestCase {
 		$this->assertSame( 'Option 1', $this->form->get_setting( 'option_1' ) );
 		$this->assertSame( 'Option 2', $this->form->get_setting( 'option_2' ) );
 		$this->assertSame( 'Option 3', $this->form->get_setting( 'option_3' ) );
+	}
+
+	public function test_get_form_control_returns_text_control() {
+		$this->form->shouldReceive( 'get_text_control' )
+			->once()
+			->with(
+				[
+					'control'     => 'text',
+					'placeholder' => 'Text Placeholder',
+					'label'       => 'Text Label',
+					'summary'     => 'Text Summary',
+				],
+				'text_name'
+			)
+			->andReturn( 'Text Control' );
+
+		$control = $this->form->get_form_control(
+			[
+				'control'     => 'text',
+				'placeholder' => 'Text Placeholder',
+				'label'       => 'Text Label',
+				'summary'     => 'Text Summary',
+			],
+			'text_name'
+		);
+
+		$this->assertSame( 'Text Control', $control );
+	}
+
+	public function test_get_form_control_returns_select_control() {
+		$this->form->shouldReceive( 'get_select_control' )
+			->once()
+			->with(
+				[
+					'control'     => 'select',
+					'placeholder' => 'Select Placeholder',
+					'label'       => 'Select Label',
+					'summary'     => 'Select Summary',
+				],
+				'select_name'
+			)
+			->andReturn( 'Select Control' );
+
+		$control = $this->form->get_form_control(
+			[
+				'control'     => 'select',
+				'placeholder' => 'Select Placeholder',
+				'label'       => 'Select Label',
+				'summary'     => 'Select Summary',
+			],
+			'select_name'
+		);
+
+		$this->assertSame( 'Select Control', $control );
+	}
+
+	public function test_get_form_control_returns_checkbox_control() {
+		$this->form->shouldReceive( 'get_checkbox_control' )
+			->once()
+			->with(
+				[
+					'control'     => 'checkbox',
+					'placeholder' => 'Checkbox Placeholder',
+					'label'       => 'Checkbox Label',
+					'summary'     => 'Checkbox Summary',
+				],
+				'checkbox_name'
+			)
+			->andReturn( 'Checkbox Control' );
+
+		$control = $this->form->get_form_control(
+			[
+				'control'     => 'checkbox',
+				'placeholder' => 'Checkbox Placeholder',
+				'label'       => 'Checkbox Label',
+				'summary'     => 'Checkbox Summary',
+			],
+			'checkbox_name'
+		);
+
+		$this->assertSame( 'Checkbox Control', $control );
 	}
 }

--- a/tests/Admin/FormTest.php
+++ b/tests/Admin/FormTest.php
@@ -10,6 +10,7 @@ use WatermarkMyImages\Admin\Form;
  * @covers \WatermarkMyImages\Admin\Form::__construct
  * @covers \WatermarkMyImages\Admin\Form::get_options
  * @covers \WatermarkMyImages\Admin\Form::get_form
+ * @covers \WatermarkMyImages\Admin\Form::get_form_action
  */
 class FormTest extends TestCase {
 	public Form $form;
@@ -83,5 +84,37 @@ class FormTest extends TestCase {
 			</form>',
 			$plugin_form
 		);
+	}
+
+	public function test_get_form_action() {
+		$form = Mockery::mock( Form::class )->makePartial();
+		$form->shouldAllowMockingProtectedMethods();
+
+		$_SERVER['REQUEST_URI'] = 'https://example.com/\/';
+
+		\WP_Mock::userFunction( 'esc_url' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return rtrim( filter_var( $arg, FILTER_SANITIZE_URL ), '/' );
+				}
+			);
+
+		\WP_Mock::userFunction( 'sanitize_text_field' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( 'wp_unslash' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return stripslashes( $arg );
+				}
+			);
+
+		$form_action = $form->get_form_action();
+
+		$this->assertSame( 'https://example.com', $form_action );
 	}
 }

--- a/tests/Admin/FormTest.php
+++ b/tests/Admin/FormTest.php
@@ -39,4 +39,19 @@ class FormTest extends TestCase {
 	public function tearDown(): void {
 		\WP_Mock::tearDown();
 	}
+
+	public function test_get_options() {
+		$this->form->expects( $this->once() )
+			->method( 'get_form' )
+			->willReturn( 'Plugin Form' );
+
+		$this->assertSame(
+			$this->form->get_options(),
+			[
+				'title'   => 'Plugin Title',
+				'summary' => 'Plugin Summary',
+				'form'    => 'Plugin Form',
+			]
+		);
+	}
 }

--- a/tests/Admin/FormTest.php
+++ b/tests/Admin/FormTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace WatermarkMyImages\Tests\Admin;
+
+use Mockery;
+use WP_Mock\Tools\TestCase;
+use WatermarkMyImages\Admin\Form;
+
+/**
+ * @covers \WatermarkMyImages\Admin\Form::get_options
+ */
+class FormTest extends TestCase {
+	public Form $form;
+
+	public function setUp(): void {
+		\WP_Mock::setUp();
+
+		$options = [
+			'page' => [
+				'title'   => 'Plugin Title',
+				'summary' => 'Plugin Summary',
+			],
+		];
+
+		$this->form = $this->getMockBuilder( Form::class )
+			->setConstructorArgs( [ $options ] )
+			->onlyMethods(
+				[
+					'get_form',
+					'get_form_action',
+					'get_form_notice',
+					'get_form_main',
+					'get_form_submit',
+				]
+			)
+			->getMock();
+	}
+
+	public function tearDown(): void {
+		\WP_Mock::tearDown();
+	}
+}

--- a/tests/Admin/FormTest.php
+++ b/tests/Admin/FormTest.php
@@ -317,4 +317,28 @@ class FormTest extends TestCase {
 			$control
 		);
 	}
+
+	public function test_get_checkbox_control() {
+		$this->form->shouldReceive( 'get_setting' )
+			->times( 1 )->with( 'checkbox_name' )->andReturn( 'on' );
+
+		$control = $this->form->get_checkbox_control(
+			[
+				'control'     => 'checkbox',
+				'placeholder' => 'Checkbox Placeholder',
+				'label'       => 'Checkbox Label',
+				'summary'     => 'Checkbox Summary',
+			],
+			'checkbox_name'
+		);
+
+		$this->assertSame(
+			'<input
+				name="checkbox_name"
+				type="checkbox"
+				checked
+			/>',
+			$control
+		);
+	}
 }

--- a/tests/Core/ContainerTest.php
+++ b/tests/Core/ContainerTest.php
@@ -6,6 +6,8 @@ use Mockery;
 use WP_Mock\Tools\TestCase;
 
 use WatermarkMyImages\Core\Container;
+use WatermarkMyImages\Abstracts\Service;
+
 use WatermarkMyImages\Services\Admin;
 use WatermarkMyImages\Services\Attachment;
 use WatermarkMyImages\Services\Boot;
@@ -16,6 +18,17 @@ use WatermarkMyImages\Services\WooCommerce;
 
 /**
  * @covers \WatermarkMyImages\Core\Container::__construct
+ * @covers \WatermarkMyImages\Core\Container::register
+ * @covers \WatermarkMyImages\Abstracts\Service::__construct
+ * @covers \WatermarkMyImages\Abstracts\Service::get_instance
+ * @covers \WatermarkMyImages\Engine\Watermarker::__construct
+ * @covers \WatermarkMyImages\Services\Admin::register
+ * @covers \WatermarkMyImages\Services\Attachment::register
+ * @covers \WatermarkMyImages\Services\Boot::register
+ * @covers \WatermarkMyImages\Services\Logger::register
+ * @covers \WatermarkMyImages\Services\MetaData::register
+ * @covers \WatermarkMyImages\Services\PageLoad::register
+ * @covers \WatermarkMyImages\Services\WooCommerce::register
  */
 class ContainerTest extends TestCase {
 	public Container $container;
@@ -38,5 +51,185 @@ class ContainerTest extends TestCase {
 		$this->assertTrue( in_array( MetaData::class, Container::$services, true ) );
 		$this->assertTrue( in_array( PageLoad::class, Container::$services, true ) );
 		$this->assertTrue( in_array( WooCommerce::class, Container::$services, true ) );
+	}
+
+	public function test_register() {
+		$container = new Container();
+
+		/**
+		 * Hack around unset Service::$instances.
+		 *
+		 * We create instances of services so we can
+		 * have a populated version of the Service abstraction's instances.
+		 */
+		foreach ( Container::$services as $service ) {
+			$service::get_instance();
+		}
+
+		\WP_Mock::expectActionAdded(
+			'admin_init',
+			[
+				Service::$instances[ Admin::class ],
+				'register_options_init',
+			]
+		);
+
+		\WP_Mock::expectActionAdded(
+			'admin_menu',
+			[
+				Service::$instances[ Admin::class ],
+				'register_options_menu',
+			]
+		);
+
+		\WP_Mock::expectActionAdded(
+			'admin_enqueue_scripts',
+			[
+				Service::$instances[ Admin::class ],
+				'register_options_styles',
+			]
+		);
+
+		\WP_Mock::expectActionAdded(
+			'add_attachment',
+			[
+				Service::$instances[ Attachment::class ],
+				'add_watermark_on_add_attachment',
+			],
+			10,
+			1
+		);
+
+		\WP_Mock::expectActionAdded(
+			'delete_attachment',
+			[
+				Service::$instances[ Attachment::class ],
+				'remove_watermark_on_attachment_delete',
+			],
+			10,
+			1
+		);
+
+		\WP_Mock::expectFilterAdded(
+			'attachment_fields_to_edit',
+			[
+				Service::$instances[ Attachment::class ],
+				'add_watermark_attachment_fields',
+			],
+			10,
+			2
+		);
+
+		\WP_Mock::expectFilterAdded(
+			'wp_generate_attachment_metadata',
+			[
+				Service::$instances[ Attachment::class ],
+				'add_watermark_to_metadata',
+			],
+			10,
+			3
+		);
+
+		\WP_Mock::expectFilterAdded(
+			'wp_prepare_attachment_for_js',
+			[
+				Service::$instances[ Attachment::class ],
+				'show_watermark_images_on_wp_media_modal',
+			],
+			10,
+			3
+		);
+
+		\WP_Mock::expectActionAdded(
+			'init',
+			[
+				Service::$instances[ Boot::class ],
+				'register_translation',
+			],
+		);
+
+		\WP_Mock::expectActionAdded(
+			'watermark_my_images_on_add_image',
+			[
+				Service::$instances[ Logger::class ],
+				'log_watermark_errors',
+			],
+			10,
+			3
+		);
+
+		\WP_Mock::expectActionAdded(
+			'watermark_my_images_on_page_load',
+			[
+				Service::$instances[ Logger::class ],
+				'log_watermark_errors',
+			],
+			10,
+			3
+		);
+
+		\WP_Mock::expectActionAdded(
+			'watermark_my_images_on_woo_product_get_image',
+			[
+				Service::$instances[ Logger::class ],
+				'log_watermark_errors',
+			],
+			10,
+			3
+		);
+
+		\WP_Mock::expectActionAdded(
+			'watermark_my_images_on_add_image',
+			[
+				Service::$instances[ MetaData::class ],
+				'add_watermark_metadata',
+			],
+			10,
+			3
+		);
+
+		\WP_Mock::expectActionAdded(
+			'watermark_my_images_on_page_load',
+			[
+				Service::$instances[ MetaData::class ],
+				'add_watermark_metadata',
+			],
+			10,
+			3
+		);
+
+		\WP_Mock::expectActionAdded(
+			'watermark_my_images_on_woo_product_get_image',
+			[
+				Service::$instances[ MetaData::class ],
+				'add_watermark_metadata',
+			],
+			10,
+			3
+		);
+
+		\WP_Mock::expectFilterAdded(
+			'wp_get_attachment_image',
+			[
+				Service::$instances[ PageLoad::class ],
+				'register_wp_get_attachment_image',
+			],
+			10,
+			5
+		);
+
+		\WP_Mock::expectFilterAdded(
+			'woocommerce_product_get_image',
+			[
+				Service::$instances[ WooCommerce::class ],
+				'add_watermark_on_get_image',
+			],
+			10,
+			5
+		);
+
+		$container->register();
+
+		$this->assertConditionsMet();
 	}
 }

--- a/tests/Engine/ImageTest.php
+++ b/tests/Engine/ImageTest.php
@@ -13,7 +13,6 @@ use Imagine\Gd\Imagine;
 use Imagine\Image\ImageInterface as Image_Object;
 
 /**
- * @covers \WatermarkMyImages\Engine\Image::__construct
  * @covers \WatermarkMyImages\Engine\Image::get_image
  * @covers \WatermarkMyImages\Engine\Image::get_imagine
  */

--- a/tests/Engine/ImageTest.php
+++ b/tests/Engine/ImageTest.php
@@ -15,6 +15,7 @@ use Imagine\Image\ImageInterface as Image_Object;
 /**
  * @covers \WatermarkMyImages\Engine\Image::__construct
  * @covers \WatermarkMyImages\Engine\Image::get_image
+ * @covers \WatermarkMyImages\Engine\Image::get_imagine
  */
 class ImageTest extends TestCase {
 	public Image $image;
@@ -22,84 +23,87 @@ class ImageTest extends TestCase {
 	public function setUp(): void {
 		\WP_Mock::setUp();
 
-		$this->image       = new Image();
 		Watermarker::$file = __DIR__ . '/sample.png';
-
-		$this->create_mock_image( __DIR__ . '/sample.png' );
 	}
 
 	public function tearDown(): void {
 		\WP_Mock::tearDown();
-
-		$this->destroy_mock_image( __DIR__ . '/sample.png' );
 	}
 
-	public function test_get_image() {
-		$imagine      = Mockery::mock( Imagine::class )->makePartial();
+	public function test_get_image_passes_and_returns_image_object() {
+		$image = Mockery::mock( Image::class )->makePartial();
+		$image->shouldAllowMockingProtectedMethods();
+
+		$imagine = Mockery::mock( Imagine::class )->makePartial();
+		$imagine->shouldAllowMockingProtectedMethods();
+
 		$image_object = Mockery::mock( Image_Object::class )->makePartial();
+		$image_object->shouldAllowMockingProtectedMethods();
 
 		$imagine->shouldReceive( 'open' )
 			->with( __DIR__ . '/sample.png' )
 			->andReturn( $image_object );
 
-		$image_resource = $this->image->get_image();
+		$image->shouldReceive( 'get_imagine' )
+			->with( Mockery::type( Imagine::class ) )
+			->andReturn( $imagine );
 
-		$this->assertInstanceOf( Image_Object::class, $image_resource );
+		$response = $image->get_image();
+
+		$this->assertInstanceOf( Image_Object::class, $response );
 		$this->assertConditionsMet();
 	}
 
-	public function test_get_image_throws_exception() {
-		$imagine_mock = $this->createMock( Imagine::class );
-		$imagine_mock->method( 'open' )
-			->will( $this->throwException( new Exception( 'File not found' ) ) );
+	public function test_get_image_catches_and_then_throws_exception() {
+		$image = Mockery::mock( Image::class )->makePartial();
+		$image->shouldAllowMockingProtectedMethods();
 
-		\WP_Mock::userFunction(
-			'esc_html__',
-			[
-				'times'  => 1,
-				'return' => function ( $text, $domain = 'watermark-my-images' ) {
-					return $text;
-				},
-			]
-		);
+		$imagine = Mockery::mock( Imagine::class )->makePartial();
+		$imagine->shouldAllowMockingProtectedMethods();
 
-		\WP_Mock::userFunction(
-			'esc_html',
-			[
-				'times'  => 1,
-				'return' => function ( $text, $domain = 'watermark-my-images' ) {
-					return $text;
-				},
-			]
-		);
+		$imagine->shouldReceive( 'open' )
+			->with( __DIR__ . '/sample.png' )
+			->andThrow(
+				new \Exception( 'File not found' )
+			);
 
-		$reflection = new \ReflectionClass( $this->image );
-		$property   = $reflection->getProperty( 'imagine' );
+		$image->shouldReceive( 'get_imagine' )
+			->with( Mockery::type( Imagine::class ) )
+			->andReturn( $imagine );
 
-		$property->setAccessible( true );
-		$property->setValue( $this->image, $imagine_mock );
+		\WP_Mock::userFunction( 'esc_html__' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( 'esc_html' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
 
 		$this->expectException( Exception::class );
 		$this->expectExceptionMessage( 'Unable to open Image Resource, File not found' );
 
-		$this->image->get_image();
+		$response = $image->get_image();
+
+		$this->assertInstanceOf( Image_Object::class, $response );
+		$this->assertConditionsMet();
 	}
 
-	public function create_mock_image( $image_file_name ) {
-		// Create a blank image.
-		$width  = 400;
-		$height = 200;
-		$image  = imagecreatetruecolor( $width, $height );
+	public function test_get_imagine_returns_imagine_instance() {
+		$image = Mockery::mock( Image::class )->makePartial();
+		$image->shouldAllowMockingProtectedMethods();
 
-		// Set background color.
-		$bg_color = imagecolorallocate( $image, 255, 255, 255 );
-		imagefill( $image, 0, 0, $bg_color );
-		imagejpeg( $image, $image_file_name );
-	}
+		$imagine = Mockery::mock( Imagine::class )->makePartial();
+		$imagine->shouldAllowMockingProtectedMethods();
 
-	public function destroy_mock_image( $image_file_name ) {
-		if ( file_exists( $image_file_name ) ) {
-			unlink( $image_file_name );
-		}
+		$response = $image->get_imagine( new Imagine() );
+
+		$this->assertInstanceOf( Imagine::class, $response );
+		$this->assertConditionsMet();
 	}
 }

--- a/tests/Services/AdminTest.php
+++ b/tests/Services/AdminTest.php
@@ -362,10 +362,16 @@ class AdminTest extends TestCase {
 	}
 
 	public function test_register_options_styles() {
+		$screen = Mockery::mock( \WP_Screen::class )->makePartial();
+		$screen->shouldAllowMockingProtectedMethods();
+		$screen->id = 'toplevel_page_watermark-my-images';
+
+		\WP_Mock::userFunction( 'get_current_screen' )
+			->andReturn( $screen );
+
 		\WP_Mock::userFunction(
 			'esc_html__',
 			[
-				'times'  => 25,
 				'return' => function ( $text, $domain = 'watermark-my-images' ) {
 					return $text;
 				},
@@ -375,7 +381,6 @@ class AdminTest extends TestCase {
 		\WP_Mock::userFunction(
 			'esc_attr',
 			[
-				'times'  => 9,
 				'return' => function ( $text ) {
 					return $text;
 				},
@@ -385,7 +390,6 @@ class AdminTest extends TestCase {
 		\WP_Mock::userFunction(
 			'esc_attr__',
 			[
-				'times'  => 6,
 				'return' => function ( $text ) {
 					return $text;
 				},
@@ -405,6 +409,15 @@ class AdminTest extends TestCase {
 				'all'
 			)
 			->andReturn( null );
+
+		$this->admin->register_options_styles();
+
+		$this->assertConditionsMet();
+	}
+
+	public function test_register_options_styles_bails() {
+		\WP_Mock::userFunction( 'get_current_screen' )
+			->andReturn( '' );
 
 		$this->admin->register_options_styles();
 

--- a/tests/Services/PageLoadTest.php
+++ b/tests/Services/PageLoadTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace WatermarkMyImages\Tests\Services;
+
+use Mockery;
+use DOMDocument;
+use WP_Mock\Tools\TestCase;
+use WatermarkMyImages\Abstracts\Service;
+use WatermarkMyImages\Engine\Watermarker;
+use WatermarkMyImages\Services\PageLoad;
+
+/**
+ * @covers \WatermarkMyImages\Services\PageLoad::__construct
+ * @covers \WatermarkMyImages\Services\PageLoad::register
+ * @covers \WatermarkMyImages\Services\PageLoad::register_wp_get_attachment_image
+ * @covers \WatermarkMyImages\Engine\Watermarker::__construct
+ * @covers wmig_get_settings
+ */
+class PageLoadTest extends TestCase {
+	public PageLoad $page_load;
+
+	public function setUp(): void {
+		\WP_Mock::setUp();
+
+		$this->page_load = new PageLoad();
+
+		$this->create_mock_image( __DIR__ . '/sample.png' );
+	}
+
+	public function tearDown(): void {
+		\WP_Mock::tearDown();
+
+		$this->destroy_mock_image( __DIR__ . '/sample.png' );
+	}
+
+	public function test_register() {
+		\WP_Mock::expectFilterAdded( 'wp_get_attachment_image', [ $this->page_load, 'register_wp_get_attachment_image' ], 10, 5 );
+
+		$this->page_load->register();
+
+		$this->assertConditionsMet();
+	}
+
+	public function test_register_wp_get_attachment_image_bails_out_on_empty() {
+		$html = $this->page_load->register_wp_get_attachment_image(
+			'',
+			1,
+			[],
+			false,
+			[]
+		);
+
+		$this->assertSame( $html, '' );
+		$this->assertConditionsMet();
+	}
+
+	public function test_register_wp_get_attachment_image_bails_out_if_options_is_not_enabled() {
+		\WP_Mock::userFunction( 'get_option' )
+			->once()
+			->with( 'watermark_my_images', [] )
+			->andReturn(
+				[
+					'page_load' => false,
+				]
+			);
+
+		$html = $this->page_load->register_wp_get_attachment_image(
+			'<p><img src="sample.jpeg"/></p>',
+			1,
+			[],
+			false,
+			[]
+		);
+
+		$this->assertSame( $html, '<p><img src="sample.jpeg"/></p>' );
+		$this->assertConditionsMet();
+	}
+
+	public function test_register_wp_get_attachment_image_passes_correctly() {
+		$page_load = Mockery::mock( PageLoad::class )->makePartial();
+		$page_load->shouldAllowMockingProtectedMethods();
+
+		\WP_Mock::userFunction( 'get_option' )
+			->once()
+			->with( 'watermark_my_images', [] )
+			->andReturn(
+				[
+					'page_load' => true,
+				]
+			);
+
+		$page_load->shouldReceive( 'get_watermark_html' )
+			->with( '<p><img src="https://example.com/wp-content/uploads/sample.jpeg"/></p>', 1 )
+			->andReturnUsing(
+				function ( $arg ) {
+					return str_replace( '.jpeg', '-watermark.jpeg', $arg );
+				}
+			);
+
+		\WP_Mock::expectFilter(
+			'watermark_my_images_attachment_html',
+			'<p><img src="https://example.com/wp-content/uploads/sample-watermark.jpeg"/></p>',
+			1
+		);
+
+		$html = $page_load->register_wp_get_attachment_image(
+			'<p><img src="https://example.com/wp-content/uploads/sample.jpeg"/></p>',
+			1,
+			[],
+			false,
+			[]
+		);
+
+		$this->assertConditionsMet();
+		$this->assertSame(
+			'<p><img src="https://example.com/wp-content/uploads/sample-watermark.jpeg"/></p>',
+			$html
+		);
+	}
+
+	public function create_mock_image( $image_file_name ) {
+		// Create a blank image.
+		$width  = 400;
+		$height = 200;
+		$image  = imagecreatetruecolor( $width, $height );
+
+		// Set background color.
+		$bg_color = imagecolorallocate( $image, 255, 255, 255 );
+		imagefill( $image, 0, 0, $bg_color );
+		imagejpeg( $image, $image_file_name );
+	}
+
+	public function destroy_mock_image( $image_file_name ) {
+		if ( file_exists( $image_file_name ) ) {
+			unlink( $image_file_name );
+		}
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,6 +11,8 @@
 // First we need to load the composer autoloader.
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 
+DG\BypassFinals::enable();
+
 // Bootstrap WP_Mock.
 WP_Mock::activateStrictMode();
 WP_Mock::bootstrap();


### PR DESCRIPTION
This PR refactors Service Instances.

## Description / Background Context

This PR focuses on refactoring Service Instances via Dependency Injection.

## Testing Instructions

1. Pull PR to local.
2. Run unit tests by running `composer run test`
3. All test cases should pass.
4. Observe that there are no regression with previous functionality.