### PR TITLE
Feat: Add more plugins options page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.0
+* Feat: Add `More Plugins` options page.
+
 ## 1.2.0
 * Chore: Update CI/CD pipeline.
 * Tested up to WP 7.0.

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     }
   ],
   "require": {
-    "imagine/imagine": "^1.3"
+    "imagine/imagine": "^1.3",
+    "badasswp/pluginate": "^1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.6",

--- a/inc/Services/Admin.php
+++ b/inc/Services/Admin.php
@@ -12,7 +12,27 @@ use WatermarkMyImages\Admin\Options;
 use WatermarkMyImages\Abstracts\Service;
 use WatermarkMyImages\Interfaces\Registrable;
 
+use Pluginate\Admin as Pluginate;
+
 class Admin extends Service implements Registrable {
+	/**
+	 * Pluginate instance.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @var Pluginate
+	 */
+	public Pluginate $pluginate;
+
+	/**
+	 * Admin constructor.
+	 *
+	 * @since 1.3.0
+	 */
+	public function __construct() {
+		$this->pluginate = new Pluginate( 'watermark-my-images' );
+	}
+
 	/**
 	 * Bind to WP.
 	 *
@@ -24,6 +44,7 @@ class Admin extends Service implements Registrable {
 		add_action( 'admin_init', [ $this, 'register_options_init' ] );
 		add_action( 'admin_menu', [ $this, 'register_options_menu' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'register_options_styles' ] );
+		add_action( 'admin_init', [ $this->pluginate, 'init' ] );
 	}
 
 	/**
@@ -44,6 +65,15 @@ class Admin extends Service implements Registrable {
 			[ $this, 'register_options_page' ],
 			'dashicons-format-image',
 			100
+		);
+
+		add_submenu_page(
+			Options::get_page_slug(),
+			__( 'More Plugins', 'watermark-my-images' ),
+			__( 'More Plugins', 'watermark-my-images' ),
+			'manage_options',
+			sprintf( '%s-more-plugins', Options::get_page_slug() ),
+			[ $this, 'register_more_plugins' ]
 		);
 	}
 
@@ -67,6 +97,35 @@ class Admin extends Service implements Registrable {
 			array_map(
 				'__',
 				( new Form( Options::$form ) )->get_options()
+			)
+		);
+	}
+
+	/**
+	 * Register More Plugins.
+	 *
+	 * This controls the display of the
+	 * "More Plugins" submenu page.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return void
+	 */
+	public function register_more_plugins(): void {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		vprintf(
+			'<section class="wrap">
+				<h1>%s</h1>
+				<p>%s</p>
+				%s
+			</section>',
+			array_map(
+				'__',
+				[
+					'More Plugins',
+					'Check out some other amazing plugin of ours...',
+					$this->pluginate->get_more_plugins(),
+				]
 			)
 		);
 	}
@@ -129,7 +188,7 @@ class Admin extends Service implements Registrable {
 		$screen = get_current_screen();
 
 		// Bail out, if not plugin Admin page.
-		if ( ! is_object( $screen ) || 'toplevel_page_watermark-my-images' !== $screen->id ) {
+		if ( ! is_object( $screen ) || ! str_contains( $screen->id, Options::get_page_slug() ) ) {
 			return;
 		}
 

--- a/tests/Core/ContainerTest.php
+++ b/tests/Core/ContainerTest.php
@@ -2,7 +2,6 @@
 
 namespace WatermarkMyImages\Tests\Core;
 
-use Mockery;
 use WP_Mock\Tools\TestCase;
 
 use WatermarkMyImages\Core\Container;
@@ -29,6 +28,7 @@ use WatermarkMyImages\Services\WooCommerce;
  * @covers \WatermarkMyImages\Services\MetaData::register
  * @covers \WatermarkMyImages\Services\PageLoad::register
  * @covers \WatermarkMyImages\Services\WooCommerce::register
+ * @covers \WatermarkMyImages\Services\Admin::__construct
  */
 class ContainerTest extends TestCase {
 	public Container $container;
@@ -87,6 +87,16 @@ class ContainerTest extends TestCase {
 			[
 				Service::$instances[ Admin::class ],
 				'register_options_styles',
+			]
+		);
+
+		$admin = Service::$instances[ Admin::class ];
+
+		\WP_Mock::expectActionAdded(
+			'admin_init',
+			[
+				$admin->pluginate,
+				'init',
 			]
 		);
 

--- a/tests/Services/AdminTest.php
+++ b/tests/Services/AdminTest.php
@@ -54,7 +54,7 @@ class AdminTest extends TestCase {
 		\WP_Mock::userFunction(
 			'esc_html__',
 			[
-				'times'  => 81,
+				'times'  => 135,
 				'return' => function ( $text, $domain = 'watermark-my-images' ) {
 					return $text;
 				},
@@ -64,7 +64,7 @@ class AdminTest extends TestCase {
 		\WP_Mock::userFunction(
 			'esc_attr',
 			[
-				'times'  => 30,
+				'times'  => 50,
 				'return' => function ( $text ) {
 					return $text;
 				},
@@ -74,7 +74,7 @@ class AdminTest extends TestCase {
 		\WP_Mock::userFunction(
 			'esc_attr__',
 			[
-				'times'  => 18,
+				'times'  => 30,
 				'return' => function ( $text ) {
 					return $text;
 				},

--- a/tests/Services/AdminTest.php
+++ b/tests/Services/AdminTest.php
@@ -22,6 +22,7 @@ use WatermarkMyImages\Abstracts\Service;
  * @covers \WatermarkMyImages\Admin\Options::get_form_page
  * @covers \WatermarkMyImages\Admin\Options::get_form_submit
  * @covers \WatermarkMyImages\Admin\Options::init
+ * @covers \WatermarkMyImages\Services\Admin::__construct
  */
 class AdminTest extends TestCase {
 	public Admin $admin;
@@ -42,6 +43,7 @@ class AdminTest extends TestCase {
 		\WP_Mock::expectActionAdded( 'admin_init', [ $this->admin, 'register_options_init' ] );
 		\WP_Mock::expectActionAdded( 'admin_menu', [ $this->admin, 'register_options_menu' ] );
 		\WP_Mock::expectActionAdded( 'admin_enqueue_scripts', [ $this->admin, 'register_options_styles' ] );
+		\WP_Mock::expectActionAdded( 'admin_init', [ $this->admin->pluginate, 'init' ] );
 
 		$this->admin->register();
 
@@ -89,6 +91,21 @@ class AdminTest extends TestCase {
 				'dashicons-format-image',
 				100
 			);
+
+		\WP_Mock::userFunction( '__' )
+			->andReturnUsing( fn( $text, $domain ) => $text );
+
+		\WP_Mock::userFunction( 'add_submenu_page' )
+			->once()
+			->with(
+				'watermark-my-images',
+				'More Plugins',
+				'More Plugins',
+				'manage_options',
+				'watermark-my-images-more-plugins',
+				[ $this->admin, 'register_more_plugins' ]
+			)
+			->andReturn( null );
 
 		$this->admin->register_options_menu();
 


### PR DESCRIPTION
This PR resolves [WP-242](https://appworld.atlassian.net/browse/WP-242)

## Description / Background Context

This PR introduces a new More Plugins options page via the Pluginate repo.

## Testing Instructions

- Pull PR to local.
- Run `composer update` to pull in the `Pluginate` package.
- Proceed to the **More Plugins** page under the **Watermark My Images** menu.
- Observe that everything still works correctly as expected and you can install and activate a plugin from same.

## Screenshots / Screencast

<img width="953" height="440" alt="Screenshot 2026-06-11 125644" src="https://github.com/user-attachments/assets/b365c978-424c-4f1e-abc5-49e59a8aad33" />



---



