### PR TITLE
Refactor: Replace fully qualified path with use counterpart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.3.0
 * Feat: Add `More Plugins` options page.
+* Refactor: Replaced fully qualified path with their use counter part.
 
 ## 1.2.0
 * Chore: Update CI/CD pipeline.

--- a/inc/Engine/Image.php
+++ b/inc/Engine/Image.php
@@ -10,6 +10,7 @@
 
 namespace WatermarkMyImages\Engine;
 
+use Exception;
 use Imagine\Gd\Imagine;
 use Imagine\Image\ImageInterface as Image_Object;
 
@@ -26,8 +27,8 @@ class Image extends Entity {
 	public function get_image(): Image_Object {
 		try {
 			return $this->get_imagine( new Imagine() )->open( Watermarker::$file );
-		} catch ( \Exception $e ) {
-			throw new \Exception(
+		} catch ( Exception $e ) {
+			throw new Exception(
 				sprintf(
 					/* translators: Exception error message. */
 					esc_html__( 'Unable to open Image Resource, %s', 'watermark-my-images' ),

--- a/inc/Engine/Text.php
+++ b/inc/Engine/Text.php
@@ -10,6 +10,7 @@
 
 namespace WatermarkMyImages\Engine;
 
+use Exception;
 use Imagine\Gd\Font;
 use Imagine\Gd\Image;
 use Imagine\Image\Box;
@@ -107,8 +108,8 @@ class Text extends Entity {
 	protected function get_font(): Font {
 		try {
 			$tx_color = $this->get_rgb( new RGB() )->color( $this->get_option( 'tx_color' ), (int) $this->get_option( 'tx_opacity' ) );
-		} catch ( \Exception $e ) {
-			throw new \Exception(
+		} catch ( Exception $e ) {
+			throw new Exception(
 				sprintf(
 					/* translators: Exception error message. */
 					esc_html__( 'Unable to create Text color, %s', 'watermark-my-images' ),
@@ -138,8 +139,8 @@ class Text extends Entity {
 	public function get_text(): Image {
 		try {
 			$bg_color = $this->get_rgb( new RGB() )->color( $this->get_option( 'bg_color' ), (int) $this->get_option( 'bg_opacity' ) );
-		} catch ( \Exception $e ) {
-			throw new \Exception(
+		} catch ( Exception $e ) {
+			throw new Exception(
 				sprintf(
 					/* translators: Exception error message. */
 					esc_html__( 'Unable to create Background color, %s', 'watermark-my-images' ),
@@ -153,8 +154,8 @@ class Text extends Entity {
 				$this->get_text_box(),
 				$bg_color
 			);
-		} catch ( \Exception $e ) {
-			throw new \Exception(
+		} catch ( Exception $e ) {
+			throw new Exception(
 				sprintf(
 					/* translators: Exception error message. */
 					esc_html__( 'Unable to create Text Box, %s', 'watermark-my-images' ),
@@ -169,8 +170,8 @@ class Text extends Entity {
 				$this->get_font(),
 				new Point( 0, 0 )
 			);
-		} catch ( \Exception $e ) {
-			throw new \Exception(
+		} catch ( Exception $e ) {
+			throw new Exception(
 				sprintf(
 					/* translators: Exception error message. */
 					esc_html__( 'Unable to draw Text, %s', 'watermark-my-images' ),

--- a/inc/Engine/Watermarker.php
+++ b/inc/Engine/Watermarker.php
@@ -10,6 +10,7 @@
 
 namespace WatermarkMyImages\Engine;
 
+use Exception;
 use Imagine\Gd\Imagine;
 use Imagine\Image\Point;
 use Imagine\Gd\Image as Text_Object;
@@ -69,7 +70,7 @@ class Watermarker {
 		static::$file = is_null( $file ) ? get_attached_file( $this->service->image_id ) : $file;
 
 		if ( ! file_exists( static::$file ) ) {
-			throw new \Exception(
+			throw new Exception(
 				sprintf(
 					/* translators: Image ID. */
 					esc_html__( 'Unable to create Image watermark, file does not exist for Image ID: %d.', 'watermark-my-images' ),
@@ -80,7 +81,7 @@ class Watermarker {
 
 		try {
 			$image = ( new Image() )->get_image();
-		} catch ( \Exception $e ) {
+		} catch ( Exception $e ) {
 			throw new ImageException(
 				sprintf(
 					/* translators: Exception error message. */
@@ -94,7 +95,7 @@ class Watermarker {
 
 		try {
 			$text = ( new Text() )->get_text();
-		} catch ( \Exception $e ) {
+		} catch ( Exception $e ) {
 			throw new TextException(
 				sprintf(
 					/* translators: Exception error message. */
@@ -108,7 +109,7 @@ class Watermarker {
 
 		try {
 			$image->paste( $text, $this->get_position( $image, $text ) );
-		} catch ( \Exception $e ) {
+		} catch ( Exception $e ) {
 			throw new PasteException(
 				sprintf(
 					/* translators: Exception error message. */
@@ -122,7 +123,7 @@ class Watermarker {
 
 		try {
 			$image->save( $this->get_watermark_abs_path() );
-		} catch ( \Exception $e ) {
+		} catch ( Exception $e ) {
 			throw new SaveException(
 				sprintf(
 					/* translators: Exception error message. */

--- a/inc/Exceptions/ImageException.php
+++ b/inc/Exceptions/ImageException.php
@@ -10,7 +10,9 @@
 
 namespace WatermarkMyImages\Exceptions;
 
-class ImageException extends \Exception {
+use Exception;
+
+class ImageException extends Exception {
 	/**
 	 * Context.
 	 *

--- a/inc/Exceptions/PasteException.php
+++ b/inc/Exceptions/PasteException.php
@@ -10,7 +10,9 @@
 
 namespace WatermarkMyImages\Exceptions;
 
-class PasteException extends \Exception {
+use Exception;
+
+class PasteException extends Exception {
 	/**
 	 * Context.
 	 *

--- a/inc/Exceptions/SaveException.php
+++ b/inc/Exceptions/SaveException.php
@@ -10,7 +10,9 @@
 
 namespace WatermarkMyImages\Exceptions;
 
-class SaveException extends \Exception {
+use Exception;
+
+class SaveException extends Exception {
 	/**
 	 * Context.
 	 *

--- a/inc/Exceptions/TextException.php
+++ b/inc/Exceptions/TextException.php
@@ -10,7 +10,9 @@
 
 namespace WatermarkMyImages\Exceptions;
 
-class TextException extends \Exception {
+use Exception;
+
+class TextException extends Exception {
 	/**
 	 * Context.
 	 *

--- a/inc/Services/Attachment.php
+++ b/inc/Services/Attachment.php
@@ -10,6 +10,8 @@
 
 namespace WatermarkMyImages\Services;
 
+use WP_Error;
+use Exception;
 use WatermarkMyImages\Abstracts\Service;
 use WatermarkMyImages\Interfaces\Registrable;
 
@@ -64,8 +66,8 @@ class Attachment extends Service implements Registrable {
 		try {
 			$watermark = $this->watermarker->get_watermark();
 			$response  = $watermark['rel'] ?? '';
-		} catch ( \Exception $e ) {
-			$response = new \WP_Error(
+		} catch ( Exception $e ) {
+			$response = new WP_Error(
 				'watermark-log-error',
 				sprintf(
 					'Fatal Error: %s',

--- a/inc/Services/PageLoad.php
+++ b/inc/Services/PageLoad.php
@@ -7,6 +7,8 @@
 
 namespace WatermarkMyImages\Services;
 
+use WP_Error;
+use Exception;
 use DOMDocument;
 use WatermarkMyImages\Abstracts\Service;
 use WatermarkMyImages\Interfaces\Registrable;
@@ -143,8 +145,8 @@ class PageLoad extends Service implements Registrable {
 		try {
 			$watermark = $this->watermarker->get_watermark( $img_metadata );
 			$response  = $watermark['rel'] ?? '';
-		} catch ( \Exception $e ) {
-			$response = new \WP_Error(
+		} catch ( Exception $e ) {
+			$response = new WP_Error(
 				'watermark-log-error',
 				sprintf(
 					'Fatal Error: %s',

--- a/inc/Services/WooCommerce.php
+++ b/inc/Services/WooCommerce.php
@@ -10,6 +10,8 @@
 
 namespace WatermarkMyImages\Services;
 
+use WP_Error;
+use Exception;
 use DOMDocument;
 use WatermarkMyImages\Abstracts\Service;
 use WatermarkMyImages\Interfaces\Registrable;
@@ -89,8 +91,8 @@ class WooCommerce extends Service implements Registrable {
 			$watermark  = $this->watermarker->get_watermark();
 			$response   = $watermark['rel'] ?? '';
 			$image_html = $this->get_image_html( $image_html, $watermark['rel'] );
-		} catch ( \Exception $e ) {
-			$response = new \WP_Error(
+		} catch ( Exception $e ) {
+			$response = new WP_Error(
 				'watermark-log-error',
 				sprintf(
 					'Fatal Error: %s',

--- a/readme.txt
+++ b/readme.txt
@@ -50,7 +50,7 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 
 == Changelog ==
 
-= 1.3.0
+= 1.3.0 =
 * Feat: Add `More Plugins` options page.
 * Refactor: Replaced fully qualified path with their use counter part.
 

--- a/readme.txt
+++ b/readme.txt
@@ -50,6 +50,10 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 
 == Changelog ==
 
+= 1.3.0
+* Feat: Add `More Plugins` options page.
+* Refactor: Replaced fully qualified path with their use counter part.
+
 = 1.2.0 =
 * Chore: Update CI/CD pipeline.
 * Tested up to WP 7.0.

--- a/tests/Abstracts/ServiceTest.php
+++ b/tests/Abstracts/ServiceTest.php
@@ -2,7 +2,7 @@
 
 namespace WatermarkMyImages\Tests\Abstracts;
 
-use Mockery;
+use WP_Mock;
 use WP_Mock\Tools\TestCase;
 use WatermarkMyImages\Abstracts\Service;
 use WatermarkMyImages\Engine\Watermarker;
@@ -14,11 +14,11 @@ use WatermarkMyImages\Engine\Watermarker;
  */
 class ServiceTest extends TestCase {
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_get_instance_returns_same_instance() {

--- a/tests/Admin/FormTest.php
+++ b/tests/Admin/FormTest.php
@@ -2,7 +2,9 @@
 
 namespace WatermarkMyImages\Tests\Admin;
 
+use WP_Mock;
 use Mockery;
+use ReflectionClass;
 use WP_Mock\Tools\TestCase;
 use WatermarkMyImages\Admin\Form;
 
@@ -26,12 +28,12 @@ class FormTest extends TestCase {
 	public Form $form;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->form = Mockery::mock( Form::class )->makePartial();
 		$this->form->shouldAllowMockingProtectedMethods();
 
-		$reflection = new \ReflectionClass( $this->form );
+		$reflection = new ReflectionClass( $this->form );
 		$property   = $reflection->getProperty( 'options' );
 		$property->setAccessible( true );
 		$property->setValue(
@@ -67,7 +69,7 @@ class FormTest extends TestCase {
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_get_options() {
@@ -112,21 +114,21 @@ class FormTest extends TestCase {
 	public function test_get_form_action() {
 		$_SERVER['REQUEST_URI'] = 'https://example.com/\/';
 
-		\WP_Mock::userFunction( 'esc_url' )
+		WP_Mock::userFunction( 'esc_url' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return rtrim( filter_var( $arg, FILTER_SANITIZE_URL ), '/' );
 				}
 			);
 
-		\WP_Mock::userFunction( 'sanitize_text_field' )
+		WP_Mock::userFunction( 'sanitize_text_field' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;
 				}
 			);
 
-		\WP_Mock::userFunction( 'wp_unslash' )
+		WP_Mock::userFunction( 'wp_unslash' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return stripslashes( $arg );
@@ -139,7 +141,7 @@ class FormTest extends TestCase {
 	}
 
 	public function test_get_form_main() {
-		\WP_Mock::expectFilter(
+		WP_Mock::expectFilter(
 			'watermark_my_images_form_fields',
 			[
 				'form_group_1',
@@ -221,7 +223,7 @@ class FormTest extends TestCase {
 	}
 
 	public function test_get_setting() {
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->with( 'plugin_option', [] )
 			->andReturn(
 				[
@@ -390,7 +392,7 @@ class FormTest extends TestCase {
 	}
 
 	public function test_get_form_submit() {
-		\WP_Mock::userFunction( 'wp_nonce_field' )
+		WP_Mock::userFunction( 'wp_nonce_field' )
 			->with( 'nonce_action', 'nonce_name', true, false )
 			->andReturn( '<input type="hidden" id="nonce_name" name="nonce_name" value="a8gkfhvzhi" />' );
 
@@ -416,21 +418,21 @@ class FormTest extends TestCase {
 		$_POST['button_name'] = null;
 		$_POST['nonce_name']  = 'nonce_action\/';
 
-		\WP_Mock::userFunction( 'wp_unslash' )
+		WP_Mock::userFunction( 'wp_unslash' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return rtrim( stripslashes( $arg ), '/' );
 				}
 			);
 
-		\WP_Mock::userFunction( 'sanitize_text_field' )
+		WP_Mock::userFunction( 'sanitize_text_field' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;
 				}
 			);
 
-		\WP_Mock::userFunction( 'wp_verify_nonce' )
+		WP_Mock::userFunction( 'wp_verify_nonce' )
 			->andReturnUsing(
 				function ( $arg1, $arg2 ) {
 					return $arg1 === $arg2;
@@ -449,21 +451,21 @@ class FormTest extends TestCase {
 		$_POST['button_name'] = true;
 		$_POST['nonce_name']  = 'incorrect_action_name\/';
 
-		\WP_Mock::userFunction( 'wp_unslash' )
+		WP_Mock::userFunction( 'wp_unslash' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return rtrim( stripslashes( $arg ), '/' );
 				}
 			);
 
-		\WP_Mock::userFunction( 'sanitize_text_field' )
+		WP_Mock::userFunction( 'sanitize_text_field' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;
 				}
 			);
 
-		\WP_Mock::userFunction( 'wp_verify_nonce' )
+		WP_Mock::userFunction( 'wp_verify_nonce' )
 			->andReturnUsing(
 				function ( $arg1, $arg2 ) {
 					return $arg1 === $arg2;
@@ -482,21 +484,21 @@ class FormTest extends TestCase {
 		$_POST['button_name'] = true;
 		$_POST['nonce_name']  = 'nonce_action\/';
 
-		\WP_Mock::userFunction( 'wp_unslash' )
+		WP_Mock::userFunction( 'wp_unslash' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return rtrim( stripslashes( $arg ), '/' );
 				}
 			);
 
-		\WP_Mock::userFunction( 'sanitize_text_field' )
+		WP_Mock::userFunction( 'sanitize_text_field' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;
 				}
 			);
 
-		\WP_Mock::userFunction( 'wp_verify_nonce' )
+		WP_Mock::userFunction( 'wp_verify_nonce' )
 			->andReturnUsing(
 				function ( $arg1, $arg2 ) {
 					return $arg1 === $arg2;

--- a/tests/Admin/OptionsTest.php
+++ b/tests/Admin/OptionsTest.php
@@ -2,7 +2,7 @@
 
 namespace WatermarkMyImages\Tests\Admin;
 
-use Mockery;
+use WP_Mock;
 use WP_Mock\Tools\TestCase;
 use WatermarkMyImages\Admin\Options;
 
@@ -14,15 +14,15 @@ use WatermarkMyImages\Admin\Options;
  */
 class OptionsTest extends TestCase {
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_get_form_page() {
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_html__',
 			[
 				'times'  => 2,
@@ -46,7 +46,7 @@ class OptionsTest extends TestCase {
 	}
 
 	public function test_get_form_submit() {
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_html__',
 			[
 				'times'  => 2,
@@ -75,7 +75,7 @@ class OptionsTest extends TestCase {
 	}
 
 	public function test_get_form_fields() {
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_html__',
 			[
 				'times'  => 22,
@@ -85,7 +85,7 @@ class OptionsTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_attr',
 			[
 				'times'  => 10,
@@ -95,7 +95,7 @@ class OptionsTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_attr__',
 			[
 				'times'  => 6,
@@ -181,7 +181,7 @@ class OptionsTest extends TestCase {
 	}
 
 	public function test_get_form_notice() {
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_html__',
 			[
 				'times'  => 1,

--- a/tests/Core/ContainerTest.php
+++ b/tests/Core/ContainerTest.php
@@ -2,6 +2,7 @@
 
 namespace WatermarkMyImages\Tests\Core;
 
+use WP_Mock;
 use WP_Mock\Tools\TestCase;
 
 use WatermarkMyImages\Core\Container;
@@ -34,11 +35,11 @@ class ContainerTest extends TestCase {
 	public Container $container;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_container_contains_required_services() {
@@ -66,7 +67,7 @@ class ContainerTest extends TestCase {
 			$service::get_instance();
 		}
 
-		\WP_Mock::expectActionAdded(
+		WP_Mock::expectActionAdded(
 			'admin_init',
 			[
 				Service::$instances[ Admin::class ],
@@ -74,7 +75,7 @@ class ContainerTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::expectActionAdded(
+		WP_Mock::expectActionAdded(
 			'admin_menu',
 			[
 				Service::$instances[ Admin::class ],
@@ -82,7 +83,7 @@ class ContainerTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::expectActionAdded(
+		WP_Mock::expectActionAdded(
 			'admin_enqueue_scripts',
 			[
 				Service::$instances[ Admin::class ],
@@ -92,7 +93,7 @@ class ContainerTest extends TestCase {
 
 		$admin = Service::$instances[ Admin::class ];
 
-		\WP_Mock::expectActionAdded(
+		WP_Mock::expectActionAdded(
 			'admin_init',
 			[
 				$admin->pluginate,
@@ -100,7 +101,7 @@ class ContainerTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::expectActionAdded(
+		WP_Mock::expectActionAdded(
 			'add_attachment',
 			[
 				Service::$instances[ Attachment::class ],
@@ -110,7 +111,7 @@ class ContainerTest extends TestCase {
 			1
 		);
 
-		\WP_Mock::expectActionAdded(
+		WP_Mock::expectActionAdded(
 			'delete_attachment',
 			[
 				Service::$instances[ Attachment::class ],
@@ -120,7 +121,7 @@ class ContainerTest extends TestCase {
 			1
 		);
 
-		\WP_Mock::expectFilterAdded(
+		WP_Mock::expectFilterAdded(
 			'attachment_fields_to_edit',
 			[
 				Service::$instances[ Attachment::class ],
@@ -130,7 +131,7 @@ class ContainerTest extends TestCase {
 			2
 		);
 
-		\WP_Mock::expectFilterAdded(
+		WP_Mock::expectFilterAdded(
 			'wp_generate_attachment_metadata',
 			[
 				Service::$instances[ Attachment::class ],
@@ -140,7 +141,7 @@ class ContainerTest extends TestCase {
 			3
 		);
 
-		\WP_Mock::expectFilterAdded(
+		WP_Mock::expectFilterAdded(
 			'wp_prepare_attachment_for_js',
 			[
 				Service::$instances[ Attachment::class ],
@@ -150,7 +151,7 @@ class ContainerTest extends TestCase {
 			3
 		);
 
-		\WP_Mock::expectActionAdded(
+		WP_Mock::expectActionAdded(
 			'init',
 			[
 				Service::$instances[ Boot::class ],
@@ -158,7 +159,7 @@ class ContainerTest extends TestCase {
 			],
 		);
 
-		\WP_Mock::expectActionAdded(
+		WP_Mock::expectActionAdded(
 			'watermark_my_images_on_add_image',
 			[
 				Service::$instances[ Logger::class ],
@@ -168,7 +169,7 @@ class ContainerTest extends TestCase {
 			3
 		);
 
-		\WP_Mock::expectActionAdded(
+		WP_Mock::expectActionAdded(
 			'watermark_my_images_on_page_load',
 			[
 				Service::$instances[ Logger::class ],
@@ -178,7 +179,7 @@ class ContainerTest extends TestCase {
 			3
 		);
 
-		\WP_Mock::expectActionAdded(
+		WP_Mock::expectActionAdded(
 			'watermark_my_images_on_woo_product_get_image',
 			[
 				Service::$instances[ Logger::class ],
@@ -188,7 +189,7 @@ class ContainerTest extends TestCase {
 			3
 		);
 
-		\WP_Mock::expectActionAdded(
+		WP_Mock::expectActionAdded(
 			'watermark_my_images_on_add_image',
 			[
 				Service::$instances[ MetaData::class ],
@@ -198,7 +199,7 @@ class ContainerTest extends TestCase {
 			3
 		);
 
-		\WP_Mock::expectActionAdded(
+		WP_Mock::expectActionAdded(
 			'watermark_my_images_on_page_load',
 			[
 				Service::$instances[ MetaData::class ],
@@ -208,7 +209,7 @@ class ContainerTest extends TestCase {
 			3
 		);
 
-		\WP_Mock::expectActionAdded(
+		WP_Mock::expectActionAdded(
 			'watermark_my_images_on_woo_product_get_image',
 			[
 				Service::$instances[ MetaData::class ],
@@ -218,7 +219,7 @@ class ContainerTest extends TestCase {
 			3
 		);
 
-		\WP_Mock::expectFilterAdded(
+		WP_Mock::expectFilterAdded(
 			'wp_get_attachment_image',
 			[
 				Service::$instances[ PageLoad::class ],
@@ -228,7 +229,7 @@ class ContainerTest extends TestCase {
 			5
 		);
 
-		\WP_Mock::expectFilterAdded(
+		WP_Mock::expectFilterAdded(
 			'woocommerce_product_get_image',
 			[
 				Service::$instances[ WooCommerce::class ],
@@ -238,7 +239,7 @@ class ContainerTest extends TestCase {
 			5
 		);
 
-		\WP_Mock::expectFilterAdded(
+		WP_Mock::expectFilterAdded(
 			'woocommerce_single_product_image_thumbnail_html',
 			[
 				Service::$instances[ WooCommerce::class ],

--- a/tests/Engine/ImageTest.php
+++ b/tests/Engine/ImageTest.php
@@ -2,6 +2,7 @@
 
 namespace WatermarkMyImages\Tests\Engine;
 
+use WP_Mock;
 use Mockery;
 use Exception;
 use WP_Mock\Tools\TestCase;
@@ -20,13 +21,13 @@ class ImageTest extends TestCase {
 	public Image $image;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		Watermarker::$file = __DIR__ . '/sample.png';
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_get_image_passes_and_returns_image_object() {
@@ -63,21 +64,21 @@ class ImageTest extends TestCase {
 		$imagine->shouldReceive( 'open' )
 			->with( __DIR__ . '/sample.png' )
 			->andThrow(
-				new \Exception( 'File not found' )
+				new Exception( 'File not found' )
 			);
 
 		$image->shouldReceive( 'get_imagine' )
 			->with( Mockery::type( Imagine::class ) )
 			->andReturn( $imagine );
 
-		\WP_Mock::userFunction( 'esc_html__' )
+		WP_Mock::userFunction( 'esc_html__' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;
 				}
 			);
 
-		\WP_Mock::userFunction( 'esc_html' )
+		WP_Mock::userFunction( 'esc_html' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;

--- a/tests/Engine/TextTest.php
+++ b/tests/Engine/TextTest.php
@@ -2,6 +2,7 @@
 
 namespace WatermarkMyImages\Tests\Engine;
 
+use WP_Mock;
 use Mockery;
 use Exception;
 use ReflectionClass;
@@ -36,14 +37,14 @@ class TextTest extends TestCase {
 	public Text $text;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->text        = new Text();
 		Watermarker::$file = __DIR__ . '/sample.png';
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_args_is_set() {
@@ -97,11 +98,11 @@ class TextTest extends TestCase {
 			'bg_opacity' => 0,
 		];
 
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->with( 'watermark_my_images', [] )
 			->andReturn( $options );
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'wp_parse_args',
 			[
 				'times'  => 1,
@@ -115,7 +116,7 @@ class TextTest extends TestCase {
 			->with( $options )
 			->andReturn( 60 );
 
-		\WP_Mock::expectFilter( 'watermark_my_images_text', $options );
+		WP_Mock::expectFilter( 'watermark_my_images_text', $options );
 
 		$options = $text->get_options();
 
@@ -148,11 +149,11 @@ class TextTest extends TestCase {
 			'bg_opacity' => 0,
 		];
 
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->with( 'watermark_my_images', [] )
 			->andReturn( $options );
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'wp_parse_args',
 			[
 				'times'  => 1,
@@ -176,7 +177,7 @@ class TextTest extends TestCase {
 			'bg_opacity' => 0,
 		];
 
-		\WP_Mock::expectFilter( 'watermark_my_images_text', $options );
+		WP_Mock::expectFilter( 'watermark_my_images_text', $options );
 
 		$options = $text->get_options();
 
@@ -219,11 +220,11 @@ class TextTest extends TestCase {
 			'bg_opacity' => 0,
 		];
 
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->with( 'watermark_my_images', [] )
 			->andReturn( $options );
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'wp_parse_args',
 			[
 				'times'  => 1,
@@ -233,7 +234,7 @@ class TextTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::onFilter( 'watermark_my_images_text' )
+		WP_Mock::onFilter( 'watermark_my_images_text' )
 			->with( $options )
 			->reply( $filtered_options );
 
@@ -319,17 +320,17 @@ class TextTest extends TestCase {
 		$rgb->shouldReceive( 'color' )
 			->with( '#FFF', 100 )
 			->andThrow(
-				new \Exception( 'Error: Unable to parse RGB color' )
+				new Exception( 'Error: Unable to parse RGB color' )
 			);
 
-		\WP_Mock::userFunction( 'esc_html__' )
+		WP_Mock::userFunction( 'esc_html__' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;
 				}
 			);
 
-		\WP_Mock::userFunction( 'esc_html' )
+		WP_Mock::userFunction( 'esc_html' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;
@@ -366,17 +367,17 @@ class TextTest extends TestCase {
 		$rgb->shouldReceive( 'color' )
 			->with( '#FFF', 100 )
 			->andThrow(
-				new \Exception( 'Error: Unable to parse Background color' )
+				new Exception( 'Error: Unable to parse Background color' )
 			);
 
-		\WP_Mock::userFunction( 'esc_html__' )
+		WP_Mock::userFunction( 'esc_html__' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;
 				}
 			);
 
-		\WP_Mock::userFunction( 'esc_html' )
+		WP_Mock::userFunction( 'esc_html' )
 			->andReturnUsing(
 				function ( $arg ) {
 					return $arg;
@@ -572,7 +573,7 @@ class TextTest extends TestCase {
 			->with( 'font' )
 			->andReturn( 'Arial' );
 
-		\WP_Mock::userFunction( 'plugin_dir_path' )
+		WP_Mock::userFunction( 'plugin_dir_path' )
 			->with( pathinfo( $reflect->getFileName(), PATHINFO_DIRNAME ) )
 			->andReturn( '/var/www/wp-content/uploads/watermark-my-images/inc/Engine' );
 

--- a/tests/Engine/WatermarkTest.php
+++ b/tests/Engine/WatermarkTest.php
@@ -2,8 +2,8 @@
 
 namespace WatermarkMyImages\Tests\Engine;
 
+use WP_Mock;
 use Mockery;
-use Exception;
 use WP_Mock\Tools\TestCase;
 
 use WatermarkMyImages\Abstracts\Service;
@@ -27,13 +27,13 @@ use Imagine\Image\Point;
  */
 class WatermarkerTest extends TestCase {
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		Watermarker::$file = '/var/www/wp-content/uploads/2024/10/sample.png';
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_get_watermark_abs_path() {
@@ -69,7 +69,7 @@ class WatermarkerTest extends TestCase {
 		$watermarker->shouldAllowMockingProtectedMethods();
 		$watermarker->service = $service;
 
-		\WP_Mock::userFunction( 'wp_get_attachment_url' )
+		WP_Mock::userFunction( 'wp_get_attachment_url' )
 			->with( 1 )
 			->andReturn( 'https://example.com/wp-content/uploads/2024/10/sample.png' );
 
@@ -128,7 +128,7 @@ class WatermarkerTest extends TestCase {
 			->with()
 			->andReturn( 100 );
 
-		\WP_Mock::expectFilter( 'watermark_my_images_text_position', [ 25, 25 ] );
+		WP_Mock::expectFilter( 'watermark_my_images_text_position', [ 25, 25 ] );
 
 		$position = $watermarker->get_position( $image, $text );
 

--- a/tests/Exceptions/ImageExceptionTest.php
+++ b/tests/Exceptions/ImageExceptionTest.php
@@ -2,7 +2,8 @@
 
 namespace WatermarkMyImages\Tests\Exceptions;
 
-use Mockery;
+use WP_Mock;
+use Exception;
 use WP_Mock\Tools\TestCase;
 use WatermarkMyImages\Exceptions\ImageException;
 
@@ -14,7 +15,7 @@ class ImageExceptionTest extends TestCase {
 	public ImageException $image_exception;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->image_exception = new ImageException(
 			'Unable to create Image Object',
@@ -24,11 +25,11 @@ class ImageExceptionTest extends TestCase {
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_instance_is_an_exception() {
-		$this->assertInstanceOf( \Exception::class, $this->image_exception );
+		$this->assertInstanceOf( Exception::class, $this->image_exception );
 	}
 
 	public function test_context_is_set() {

--- a/tests/Exceptions/PasteExceptionTest.php
+++ b/tests/Exceptions/PasteExceptionTest.php
@@ -2,7 +2,8 @@
 
 namespace WatermarkMyImages\Tests\Exceptions;
 
-use Mockery;
+use WP_Mock;
+use Exception;
 use WP_Mock\Tools\TestCase;
 use WatermarkMyImages\Exceptions\PasteException;
 
@@ -14,7 +15,7 @@ class PasteExceptionTest extends TestCase {
 	public PasteException $paste_exception;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->paste_exception = new PasteException(
 			'Unable to paste Text on Image Resource',
@@ -24,11 +25,11 @@ class PasteExceptionTest extends TestCase {
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_instance_is_an_exception() {
-		$this->assertInstanceOf( \Exception::class, $this->paste_exception );
+		$this->assertInstanceOf( Exception::class, $this->paste_exception );
 	}
 
 	public function test_context_is_set() {

--- a/tests/Exceptions/SaveExceptionTest.php
+++ b/tests/Exceptions/SaveExceptionTest.php
@@ -2,7 +2,8 @@
 
 namespace WatermarkMyImages\Tests\Exceptions;
 
-use Mockery;
+use WP_Mock;
+use Exception;
 use WP_Mock\Tools\TestCase;
 use WatermarkMyImages\Exceptions\SaveException;
 
@@ -14,7 +15,7 @@ class SaveExceptionTest extends TestCase {
 	public SaveException $save_exception;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->save_exception = new SaveException(
 			'Unable to save Text to Image Resource',
@@ -24,11 +25,11 @@ class SaveExceptionTest extends TestCase {
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_instance_is_an_exception() {
-		$this->assertInstanceOf( \Exception::class, $this->save_exception );
+		$this->assertInstanceOf( Exception::class, $this->save_exception );
 	}
 
 	public function test_context_is_set() {

--- a/tests/Exceptions/TextExceptionTest.php
+++ b/tests/Exceptions/TextExceptionTest.php
@@ -2,7 +2,8 @@
 
 namespace WatermarkMyImages\Tests\Exceptions;
 
-use Mockery;
+use WP_Mock;
+use Exception;
 use WP_Mock\Tools\TestCase;
 use WatermarkMyImages\Exceptions\TextException;
 
@@ -14,7 +15,7 @@ class TextExceptionTest extends TestCase {
 	public TextException $text_exception;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->text_exception = new TextException(
 			'Unable to create Text Object',
@@ -24,11 +25,11 @@ class TextExceptionTest extends TestCase {
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_instance_is_an_exception() {
-		$this->assertInstanceOf( \Exception::class, $this->text_exception );
+		$this->assertInstanceOf( Exception::class, $this->text_exception );
 	}
 
 	public function test_context_is_set() {

--- a/tests/Helpers/FunctionsTest.php
+++ b/tests/Helpers/FunctionsTest.php
@@ -2,6 +2,7 @@
 
 namespace WatermarkMyImages\Tests\Helpers;
 
+use WP_Mock;
 use WP_Mock\Tools\TestCase;
 
 require_once __DIR__ . '/../../inc/Helpers/functions.php';
@@ -12,7 +13,7 @@ require_once __DIR__ . '/../../inc/Helpers/functions.php';
  */
 class FunctionsTest extends TestCase {
 	public function test_wmig_get_settings() {
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->once()
 			->with( 'watermark_my_images', [] )
 			->andReturn(

--- a/tests/Interfaces/RegistrableTest.php
+++ b/tests/Interfaces/RegistrableTest.php
@@ -2,7 +2,7 @@
 
 namespace WatermarkMyImages\Tests\Interfaces;
 
-use Mockery;
+use WP_Mock;
 use WP_Mock\Tools\TestCase;
 use WatermarkMyImages\Interfaces\Registrable;
 
@@ -13,13 +13,13 @@ class RegistrableTest extends TestCase {
 	public Registrable $registrable;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->registrable = $this->getMockForAbstractClass( Registrable::class );
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_register() {

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -2,21 +2,20 @@
 
 namespace WatermarkMyImages\Tests;
 
-use Mockery;
+use WP_Mock;
 use WP_Mock\Tools\TestCase;
 use WatermarkMyImages\Plugin;
-use WatermarkMyImages\Abstracts\Service;
 
 /**
  * @covers \WatermarkMyImages\Plugin::get_instance
  */
 class PluginTest extends TestCase {
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_plugin_returns_same_instance() {

--- a/tests/Services/AdminTest.php
+++ b/tests/Services/AdminTest.php
@@ -3,11 +3,10 @@
 namespace WatermarkMyImages\Tests\Services;
 
 use Mockery;
+use WP_Mock;
+use WP_Screen;
 use WP_Mock\Tools\TestCase;
-use WatermarkMyImages\Admin\Form;
-use WatermarkMyImages\Admin\Options;
 use WatermarkMyImages\Services\Admin;
-use WatermarkMyImages\Abstracts\Service;
 
 /**
  * @covers \WatermarkMyImages\Services\Admin::__construct
@@ -28,22 +27,22 @@ class AdminTest extends TestCase {
 	public Admin $admin;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->admin = new Admin();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 
 		$_POST = [];
 	}
 
 	public function test_register() {
-		\WP_Mock::expectActionAdded( 'admin_init', [ $this->admin, 'register_options_init' ] );
-		\WP_Mock::expectActionAdded( 'admin_menu', [ $this->admin, 'register_options_menu' ] );
-		\WP_Mock::expectActionAdded( 'admin_enqueue_scripts', [ $this->admin, 'register_options_styles' ] );
-		\WP_Mock::expectActionAdded( 'admin_init', [ $this->admin->pluginate, 'init' ] );
+		WP_Mock::expectActionAdded( 'admin_init', [ $this->admin, 'register_options_init' ] );
+		WP_Mock::expectActionAdded( 'admin_menu', [ $this->admin, 'register_options_menu' ] );
+		WP_Mock::expectActionAdded( 'admin_enqueue_scripts', [ $this->admin, 'register_options_styles' ] );
+		WP_Mock::expectActionAdded( 'admin_init', [ $this->admin->pluginate, 'init' ] );
 
 		$this->admin->register();
 
@@ -51,7 +50,7 @@ class AdminTest extends TestCase {
 	}
 
 	public function test_register_options_menu() {
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_html__',
 			[
 				'times'  => 135,
@@ -61,7 +60,7 @@ class AdminTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_attr',
 			[
 				'times'  => 50,
@@ -71,7 +70,7 @@ class AdminTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_attr__',
 			[
 				'times'  => 30,
@@ -81,7 +80,7 @@ class AdminTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction( 'add_menu_page' )
+		WP_Mock::userFunction( 'add_menu_page' )
 			->with(
 				'Watermark My Images',
 				'Watermark My Images',
@@ -92,10 +91,10 @@ class AdminTest extends TestCase {
 				100
 			);
 
-		\WP_Mock::userFunction( '__' )
+		WP_Mock::userFunction( '__' )
 			->andReturnUsing( fn( $text, $domain ) => $text );
 
-		\WP_Mock::userFunction( 'add_submenu_page' )
+		WP_Mock::userFunction( 'add_submenu_page' )
 			->once()
 			->with(
 				'watermark-my-images',
@@ -113,7 +112,7 @@ class AdminTest extends TestCase {
 	}
 
 	public function test_register_options_init_bails_on_POST() {
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_html__',
 			[
 				'times'  => 81,
@@ -123,7 +122,7 @@ class AdminTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_attr',
 			[
 				'times'  => 30,
@@ -133,7 +132,7 @@ class AdminTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_attr__',
 			[
 				'times'  => 18,
@@ -149,7 +148,7 @@ class AdminTest extends TestCase {
 	}
 
 	public function test_register_options_init_bails_on_NONCE() {
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_html__',
 			[
 				'times'  => 81,
@@ -159,7 +158,7 @@ class AdminTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_attr',
 			[
 				'times'  => 30,
@@ -169,7 +168,7 @@ class AdminTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_attr__',
 			[
 				'times'  => 18,
@@ -184,15 +183,15 @@ class AdminTest extends TestCase {
 			'watermark_my_images_settings_nonce' => 'a8jfkgw2h7i',
 		];
 
-		\WP_Mock::userFunction( 'wp_unslash' )
+		WP_Mock::userFunction( 'wp_unslash' )
 			->with( 'a8jfkgw2h7i' )
 			->andReturn( 'a8jfkgw2h7i' );
 
-		\WP_Mock::userFunction( 'sanitize_text_field' )
+		WP_Mock::userFunction( 'sanitize_text_field' )
 			->with( 'a8jfkgw2h7i' )
 			->andReturn( 'a8jfkgw2h7i' );
 
-		\WP_Mock::userFunction( 'wp_verify_nonce' )
+		WP_Mock::userFunction( 'wp_verify_nonce' )
 			->with( 'a8jfkgw2h7i', 'watermark_my_images_settings_action' )
 			->andReturn( false );
 
@@ -202,7 +201,7 @@ class AdminTest extends TestCase {
 	}
 
 	public function test_register_options_init_passes() {
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_html__',
 			[
 				'times'  => 135,
@@ -212,7 +211,7 @@ class AdminTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_attr',
 			[
 				'times'  => 50,
@@ -222,7 +221,7 @@ class AdminTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_attr__',
 			[
 				'times'  => 30,
@@ -237,12 +236,12 @@ class AdminTest extends TestCase {
 			'watermark_my_images_settings_nonce' => 'a8jfkgw2h7i',
 		];
 
-		\WP_Mock::userFunction( 'wp_verify_nonce' )
+		WP_Mock::userFunction( 'wp_verify_nonce' )
 			->once()
 			->with( 'a8jfkgw2h7i', 'watermark_my_images_settings_action' )
 			->andReturn( true );
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'wp_unslash',
 			[
 				'times'  => 11,
@@ -252,7 +251,7 @@ class AdminTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'sanitize_text_field',
 			[
 				'times'  => 11,
@@ -262,7 +261,7 @@ class AdminTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction( 'update_option' )
+		WP_Mock::userFunction( 'update_option' )
 			->once()
 			->with(
 				'watermark_my_images',
@@ -287,7 +286,7 @@ class AdminTest extends TestCase {
 	}
 
 	public function test_register_options_init_updates_POST_values_that_are_set() {
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_html__',
 			[
 				'times'  => 135,
@@ -297,7 +296,7 @@ class AdminTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_attr',
 			[
 				'times'  => 50,
@@ -307,7 +306,7 @@ class AdminTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_attr__',
 			[
 				'times'  => 30,
@@ -331,12 +330,12 @@ class AdminTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction( 'wp_verify_nonce' )
+		WP_Mock::userFunction( 'wp_verify_nonce' )
 			->once()
 			->with( 'a8jfkgw2h7i', 'watermark_my_images_settings_action' )
 			->andReturn( true );
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'wp_unslash',
 			[
 				'times'  => 11,
@@ -346,7 +345,7 @@ class AdminTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'sanitize_text_field',
 			[
 				'times'  => 11,
@@ -356,7 +355,7 @@ class AdminTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction( 'update_option' )
+		WP_Mock::userFunction( 'update_option' )
 			->once()
 			->with(
 				'watermark_my_images',
@@ -381,14 +380,14 @@ class AdminTest extends TestCase {
 	}
 
 	public function test_register_options_styles() {
-		$screen = Mockery::mock( \WP_Screen::class )->makePartial();
+		$screen = Mockery::mock( WP_Screen::class )->makePartial();
 		$screen->shouldAllowMockingProtectedMethods();
 		$screen->id = 'toplevel_page_watermark-my-images';
 
-		\WP_Mock::userFunction( 'get_current_screen' )
+		WP_Mock::userFunction( 'get_current_screen' )
 			->andReturn( $screen );
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_html__',
 			[
 				'return' => function ( $text, $domain = 'watermark-my-images' ) {
@@ -397,7 +396,7 @@ class AdminTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_attr',
 			[
 				'return' => function ( $text ) {
@@ -406,7 +405,7 @@ class AdminTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'esc_attr__',
 			[
 				'return' => function ( $text ) {
@@ -415,11 +414,11 @@ class AdminTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction( 'plugins_url' )
+		WP_Mock::userFunction( 'plugins_url' )
 			->with( 'watermark-my-images/styles.css' )
 			->andReturn( 'https://example.com/wp-content/plugins/watermark-my-images/styles.css' );
 
-		\WP_Mock::userFunction( 'wp_enqueue_style' )
+		WP_Mock::userFunction( 'wp_enqueue_style' )
 			->with(
 				'watermark-my-images',
 				'https://example.com/wp-content/plugins/watermark-my-images/styles.css',
@@ -435,7 +434,7 @@ class AdminTest extends TestCase {
 	}
 
 	public function test_register_options_styles_bails() {
-		\WP_Mock::userFunction( 'get_current_screen' )
+		WP_Mock::userFunction( 'get_current_screen' )
 			->andReturn( '' );
 
 		$this->admin->register_options_styles();

--- a/tests/Services/AttachmentTest.php
+++ b/tests/Services/AttachmentTest.php
@@ -3,9 +3,9 @@
 namespace WatermarkMyImages\Tests\Services;
 
 use Mockery;
-use WP_Error;
+use WP_Mock;
+use WP_Post;
 use WP_Mock\Tools\TestCase;
-use WatermarkMyImages\Abstracts\Service;
 use WatermarkMyImages\Engine\Watermarker;
 use WatermarkMyImages\Services\Attachment;
 
@@ -24,7 +24,7 @@ class AttachmentTest extends TestCase {
 	public Attachment $attachment;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->attachment = new Attachment();
 
@@ -32,17 +32,17 @@ class AttachmentTest extends TestCase {
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 
 		$this->destroy_mock_image( __DIR__ . '/sample.png' );
 	}
 
 	public function test_register() {
-		\WP_Mock::expectActionAdded( 'add_attachment', [ $this->attachment, 'add_watermark_on_add_attachment' ], 10, 1 );
-		\WP_Mock::expectActionAdded( 'delete_attachment', [ $this->attachment, 'remove_watermark_on_attachment_delete' ], 10, 1 );
-		\WP_Mock::expectFilterAdded( 'attachment_fields_to_edit', [ $this->attachment, 'add_watermark_attachment_fields' ], 10, 2 );
-		\WP_Mock::expectFilterAdded( 'wp_generate_attachment_metadata', [ $this->attachment, 'add_watermark_to_metadata' ], 10, 3 );
-		\WP_Mock::expectFilterAdded( 'wp_prepare_attachment_for_js', [ $this->attachment, 'show_watermark_images_on_wp_media_modal' ], 10, 3 );
+		WP_Mock::expectActionAdded( 'add_attachment', [ $this->attachment, 'add_watermark_on_add_attachment' ], 10, 1 );
+		WP_Mock::expectActionAdded( 'delete_attachment', [ $this->attachment, 'remove_watermark_on_attachment_delete' ], 10, 1 );
+		WP_Mock::expectFilterAdded( 'attachment_fields_to_edit', [ $this->attachment, 'add_watermark_attachment_fields' ], 10, 2 );
+		WP_Mock::expectFilterAdded( 'wp_generate_attachment_metadata', [ $this->attachment, 'add_watermark_to_metadata' ], 10, 3 );
+		WP_Mock::expectFilterAdded( 'wp_prepare_attachment_for_js', [ $this->attachment, 'show_watermark_images_on_wp_media_modal' ], 10, 3 );
 
 		$this->attachment->register();
 
@@ -50,11 +50,11 @@ class AttachmentTest extends TestCase {
 	}
 
 	public function test_add_watermark_on_add_attachment_bails_on_upload_NOT_set() {
-		\WP_Mock::userFunction( 'get_post_meta' )
+		WP_Mock::userFunction( 'get_post_meta' )
 			->with( 1, 'watermark_my_images', true )
 			->andReturn( [] );
 
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->with( 'watermark_my_images', [] )
 			->andReturn(
 				[
@@ -68,11 +68,11 @@ class AttachmentTest extends TestCase {
 	}
 
 	public function test_add_watermark_on_add_attachment_bails_if_attachment_is_NOT_image() {
-		\WP_Mock::userFunction( 'get_post_meta' )
+		WP_Mock::userFunction( 'get_post_meta' )
 			->with( 1, 'watermark_my_images', true )
 			->andReturn( [] );
 
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->with( 'watermark_my_images', [] )
 			->andReturn(
 				[
@@ -80,7 +80,7 @@ class AttachmentTest extends TestCase {
 				]
 			);
 
-		\WP_Mock::userFunction( 'wp_attachment_is_image' )
+		WP_Mock::userFunction( 'wp_attachment_is_image' )
 			->with( 1 )
 			->andReturn( false );
 
@@ -90,7 +90,7 @@ class AttachmentTest extends TestCase {
 	}
 
 	public function test_add_watermark_on_add_attachment_bails_if_watermark_already_exists() {
-		\WP_Mock::userFunction( 'get_post_meta' )
+		WP_Mock::userFunction( 'get_post_meta' )
 			->with( 1, 'watermark_my_images', true )
 			->andReturn(
 				[
@@ -99,7 +99,7 @@ class AttachmentTest extends TestCase {
 				]
 			);
 
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->with( 'watermark_my_images', [] )
 			->andReturn(
 				[
@@ -107,7 +107,7 @@ class AttachmentTest extends TestCase {
 				]
 			);
 
-		\WP_Mock::userFunction( 'wp_attachment_is_image' )
+		WP_Mock::userFunction( 'wp_attachment_is_image' )
 			->with( 1 )
 			->andReturn( true );
 
@@ -131,11 +131,11 @@ class AttachmentTest extends TestCase {
 
 		$this->attachment->watermarker = $watermarker;
 
-		\WP_Mock::userFunction( 'get_post_meta' )
+		WP_Mock::userFunction( 'get_post_meta' )
 			->with( 1, 'watermark_my_images', true )
 			->andReturn( '' );
 
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->with( 'watermark_my_images', [] )
 			->andReturn(
 				[
@@ -143,11 +143,11 @@ class AttachmentTest extends TestCase {
 				]
 			);
 
-		\WP_Mock::userFunction( 'wp_attachment_is_image' )
+		WP_Mock::userFunction( 'wp_attachment_is_image' )
 			->with( 1 )
 			->andReturn( true );
 
-		\WP_Mock::expectAction(
+		WP_Mock::expectAction(
 			'watermark_my_images_on_add_image',
 			'https://example.com/wp-content/2024/10/sample-watermark-my-images.jpg',
 			[
@@ -163,7 +163,7 @@ class AttachmentTest extends TestCase {
 	}
 
 	public function test_add_watermark_to_attachement() {
-		\WP_Mock::userFunction( 'wp_attachment_is_image' )
+		WP_Mock::userFunction( 'wp_attachment_is_image' )
 			->once()
 			->with( 1 )
 			->andReturn( false );
@@ -177,15 +177,15 @@ class AttachmentTest extends TestCase {
 		$watermarker = Mockery::mock( Watermarker::class )->makePartial();
 		$watermarker->shouldAllowMockingProtectedMethods();
 
-		\WP_Mock::userFunction( 'wp_attachment_is_image' )
+		WP_Mock::userFunction( 'wp_attachment_is_image' )
 			->with( 1 )
 			->andReturn( true );
 
-		\WP_Mock::userFunction( 'get_attached_file' )
+		WP_Mock::userFunction( 'get_attached_file' )
 			->with( 1 )
 			->andReturn( '/var/www/html/wp-content/uploads/2024/10/sample-watermark-my-images.jpg' );
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'trailingslashit',
 			[
 				'times'  => 1,
@@ -195,7 +195,7 @@ class AttachmentTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::expectAction(
+		WP_Mock::expectAction(
 			'watermark_my_images_on_add_image_crops',
 			'https://example.com/wp-content/uploads/2024/10/full-watermark-my-images.jpg',
 			[
@@ -233,7 +233,7 @@ class AttachmentTest extends TestCase {
 	}
 
 	public function test_remove_watermark_on_attachment_delete_bails_if_NOT_image() {
-		\WP_Mock::userFunction( 'wp_attachment_is_image' )
+		WP_Mock::userFunction( 'wp_attachment_is_image' )
 			->with( 1 )
 			->andReturn( false );
 
@@ -243,15 +243,15 @@ class AttachmentTest extends TestCase {
 	}
 
 	public function test_remove_watermark_on_attachment_delete_bails_if_no_watermark_post_meta() {
-		\WP_Mock::userFunction( 'wp_attachment_is_image' )
+		WP_Mock::userFunction( 'wp_attachment_is_image' )
 			->with( 1 )
 			->andReturn( true );
 
-		\WP_Mock::userFunction( 'get_post_meta' )
+		WP_Mock::userFunction( 'get_post_meta' )
 			->with( 1, 'watermark_my_images', true )
 			->andReturn( '' );
 
-		\WP_Mock::userFunction( 'wp_get_attachment_metadata' )
+		WP_Mock::userFunction( 'wp_get_attachment_metadata' )
 			->with( 1 )
 			->andReturn( [] );
 
@@ -261,11 +261,11 @@ class AttachmentTest extends TestCase {
 	}
 
 	public function test_remove_watermark_on_attachment_delete_removes_parent_watermark() {
-		\WP_Mock::userFunction( 'wp_attachment_is_image' )
+		WP_Mock::userFunction( 'wp_attachment_is_image' )
 			->with( 1 )
 			->andReturn( true );
 
-		\WP_Mock::userFunction( 'get_post_meta' )
+		WP_Mock::userFunction( 'get_post_meta' )
 			->with( 1, 'watermark_my_images', true )
 			->andReturn(
 				[
@@ -274,13 +274,13 @@ class AttachmentTest extends TestCase {
 				]
 			);
 
-		\WP_Mock::userFunction( 'wp_delete_file' )
+		WP_Mock::userFunction( 'wp_delete_file' )
 			->with( __DIR__ . '/sample.png' )
 			->andReturn( true );
 
-		\WP_Mock::expectAction( 'watermark_my_images_on_delete_image', __DIR__ . '/sample.png', 1 );
+		WP_Mock::expectAction( 'watermark_my_images_on_delete_image', __DIR__ . '/sample.png', 1 );
 
-		\WP_Mock::userFunction( 'wp_get_attachment_metadata' )
+		WP_Mock::userFunction( 'wp_get_attachment_metadata' )
 			->with( 1 )
 			->andReturn( [] );
 
@@ -290,11 +290,11 @@ class AttachmentTest extends TestCase {
 	}
 
 	public function test_remove_watermark_on_attachment_delete_removes_parent_and_child_watermarks() {
-		\WP_Mock::userFunction( 'wp_attachment_is_image' )
+		WP_Mock::userFunction( 'wp_attachment_is_image' )
 			->with( 1 )
 			->andReturn( true );
 
-		\WP_Mock::userFunction( 'get_post_meta' )
+		WP_Mock::userFunction( 'get_post_meta' )
 			->with( 1, 'watermark_my_images', true )
 			->andReturn(
 				[
@@ -303,15 +303,15 @@ class AttachmentTest extends TestCase {
 				]
 			);
 
-		\WP_Mock::userFunction( 'wp_delete_file' )
+		WP_Mock::userFunction( 'wp_delete_file' )
 			->with( __DIR__ . '/sample.png' )
 			->andReturn( true );
 
-		\WP_Mock::expectAction( 'watermark_my_images_on_delete_image', __DIR__ . '/sample.png', 1 );
+		WP_Mock::expectAction( 'watermark_my_images_on_delete_image', __DIR__ . '/sample.png', 1 );
 
 		$this->create_mock_image( __DIR__ . '/thumbnail-watermark-my-images.jpg' );
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'trailingslashit',
 			[
 				'return' => function ( $url ) {
@@ -320,7 +320,7 @@ class AttachmentTest extends TestCase {
 			]
 		);
 
-		\WP_Mock::userFunction( 'wp_get_attachment_metadata' )
+		WP_Mock::userFunction( 'wp_get_attachment_metadata' )
 			->with( 1 )
 			->andReturn(
 				[
@@ -332,11 +332,11 @@ class AttachmentTest extends TestCase {
 				]
 			);
 
-		\WP_Mock::userFunction( 'wp_delete_file' )
+		WP_Mock::userFunction( 'wp_delete_file' )
 			->with( __DIR__ . '/thumbnail-watermark-my-images.jpg' )
 			->andReturn( true );
 
-		\WP_Mock::expectAction( 'watermark_my_images_on_delete_image_crops', __DIR__ . '/thumbnail-watermark-my-images.jpg', 1 );
+		WP_Mock::expectAction( 'watermark_my_images_on_delete_image_crops', __DIR__ . '/thumbnail-watermark-my-images.jpg', 1 );
 
 		$this->attachment->remove_watermark_on_attachment_delete( 1 );
 
@@ -346,11 +346,11 @@ class AttachmentTest extends TestCase {
 	}
 
 	public function test_add_watermark_attachment_fields() {
-		$post = Mockery::mock( \WP_Post::class )->makePartial();
+		$post = Mockery::mock( WP_Post::class )->makePartial();
 		$post->shouldAllowMockingProtectedMethods();
 		$post->ID = 1;
 
-		\WP_Mock::userFunction( 'get_post_meta' )
+		WP_Mock::userFunction( 'get_post_meta' )
 			->with( 1, 'watermark_my_images', true )
 			->andReturn(
 				[

--- a/tests/Services/BootTest.php
+++ b/tests/Services/BootTest.php
@@ -2,10 +2,10 @@
 
 namespace WatermarkMyImages\Tests\Services;
 
-use Mockery;
+use WP_Mock;
+use ReflectionClass;
 use WP_Mock\Tools\TestCase;
 use WatermarkMyImages\Services\Boot;
-use WatermarkMyImages\Abstracts\Service;
 
 /**
  * @covers \WatermarkMyImages\Services\Boot::__construct
@@ -17,17 +17,17 @@ class BootTest extends TestCase {
 	public Boot $boot;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->boot = new Boot();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_register() {
-		\WP_Mock::expectActionAdded( 'init', [ $this->boot, 'register_translation' ] );
+		WP_Mock::expectActionAdded( 'init', [ $this->boot, 'register_translation' ] );
 
 		$this->boot->register();
 
@@ -35,14 +35,14 @@ class BootTest extends TestCase {
 	}
 
 	public function test_register_translation() {
-		$boot = new \ReflectionClass( Boot::class );
+		$boot = new ReflectionClass( Boot::class );
 
-		\WP_Mock::userFunction( 'plugin_basename' )
+		WP_Mock::userFunction( 'plugin_basename' )
 			->once()
 			->with( $boot->getFileName() )
 			->andReturn( '/inc/Services/Boot.php' );
 
-		\WP_Mock::userFunction( 'load_plugin_textdomain' )
+		WP_Mock::userFunction( 'load_plugin_textdomain' )
 			->once()
 			->with(
 				'watermark-my-images',

--- a/tests/Services/LoggerTest.php
+++ b/tests/Services/LoggerTest.php
@@ -2,10 +2,11 @@
 
 namespace WatermarkMyImages\Tests\Services;
 
+use WP_Mock;
+use WP_Error;
 use Mockery;
 use WP_Mock\Tools\TestCase;
 use WatermarkMyImages\Services\Logger;
-use WatermarkMyImages\Abstracts\Service;
 
 require_once __DIR__ . '/../../inc/Helpers/functions.php';
 
@@ -20,19 +21,19 @@ class LoggerTest extends TestCase {
 	public Logger $logger;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->logger = new Logger();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_register() {
-		\WP_Mock::expectActionAdded( 'watermark_my_images_on_add_image', [ $this->logger, 'log_watermark_errors' ], 10, 3 );
-		\WP_Mock::expectActionAdded( 'watermark_my_images_on_page_load', [ $this->logger, 'log_watermark_errors' ], 10, 3 );
-		\WP_Mock::expectActionAdded( 'watermark_my_images_on_woo_product_get_image', [ $this->logger, 'log_watermark_errors' ], 10, 3 );
+		WP_Mock::expectActionAdded( 'watermark_my_images_on_add_image', [ $this->logger, 'log_watermark_errors' ], 10, 3 );
+		WP_Mock::expectActionAdded( 'watermark_my_images_on_page_load', [ $this->logger, 'log_watermark_errors' ], 10, 3 );
+		WP_Mock::expectActionAdded( 'watermark_my_images_on_woo_product_get_image', [ $this->logger, 'log_watermark_errors' ], 10, 3 );
 
 		$this->logger->register();
 
@@ -40,7 +41,7 @@ class LoggerTest extends TestCase {
 	}
 
 	public function test_log_watermark_errors_bails_out_early() {
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->once()
 			->with( 'watermark_my_images', [] )
 			->andReturn( [ 'logs' => false ] );
@@ -55,12 +56,12 @@ class LoggerTest extends TestCase {
 	public function test_log_watermark_errors_bails_out_if_it_is_not_wp_error() {
 		$url = 'image-1-watermark-my-images.jpg';
 
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->once()
 			->with( 'watermark_my_images', [] )
 			->andReturn( [ 'logs' => true ] );
 
-		\WP_Mock::userFunction( 'is_wp_error' )
+		WP_Mock::userFunction( 'is_wp_error' )
 			->once()
 			->with( 'image-1-watermark-my-images.jpg' )
 			->andReturn( false );
@@ -71,28 +72,28 @@ class LoggerTest extends TestCase {
 	}
 
 	public function test_log_watermark_errors_passes() {
-		$url = Mockery::mock( '\WP_Error' )->makePartial();
+		$url = Mockery::mock( 'WP_Error' )->makePartial();
 		$url->shouldAllowMockingProtectedMethods();
 
 		$url->shouldReceive( 'get_error_message' )
 			->andReturn( 'Unable to create Image Object.' );
 
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->once()
 			->with( 'watermark_my_images', [] )
 			->andReturn( [ 'logs' => true ] );
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'is_wp_error',
 			[
 				'times'  => 1,
 				'return' => function ( $url ) {
-					return $url instanceof \WP_Error;
+					return $url instanceof WP_Error;
 				},
 			]
 		);
 
-		\WP_Mock::userFunction( 'wp_insert_post' )
+		WP_Mock::userFunction( 'wp_insert_post' )
 			->once()
 			->with(
 				[

--- a/tests/Services/MetaDataTest.php
+++ b/tests/Services/MetaDataTest.php
@@ -2,10 +2,11 @@
 
 namespace WatermarkMyImages\Tests\Services;
 
+use WP_Mock;
+use WP_Error;
 use Mockery;
 use WP_Mock\Tools\TestCase;
 use WatermarkMyImages\Services\MetaData;
-use WatermarkMyImages\Abstracts\Service;
 
 /**
  * @covers \WatermarkMyImages\Services\MetaData::__construct
@@ -17,19 +18,19 @@ class MetaDataTest extends TestCase {
 	public MetaData $metadata;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->metadata = new MetaData();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 	}
 
 	public function test_register() {
-		\WP_Mock::expectActionAdded( 'watermark_my_images_on_add_image', [ $this->metadata, 'add_watermark_metadata' ], 10, 3 );
-		\WP_Mock::expectActionAdded( 'watermark_my_images_on_page_load', [ $this->metadata, 'add_watermark_metadata' ], 10, 3 );
-		\WP_Mock::expectActionAdded( 'watermark_my_images_on_woo_product_get_image', [ $this->metadata, 'add_watermark_metadata' ], 10, 3 );
+		WP_Mock::expectActionAdded( 'watermark_my_images_on_add_image', [ $this->metadata, 'add_watermark_metadata' ], 10, 3 );
+		WP_Mock::expectActionAdded( 'watermark_my_images_on_page_load', [ $this->metadata, 'add_watermark_metadata' ], 10, 3 );
+		WP_Mock::expectActionAdded( 'watermark_my_images_on_woo_product_get_image', [ $this->metadata, 'add_watermark_metadata' ], 10, 3 );
 
 		$this->metadata->register();
 
@@ -37,15 +38,15 @@ class MetaDataTest extends TestCase {
 	}
 
 	public function test_add_watermark_metadata_fails_on_is_wp_error() {
-		$error = Mockery::mock( \WP_Error::class )->makePartial();
+		$error = Mockery::mock( WP_Error::class )->makePartial();
 		$error->shouldAllowMockingProtectedMethods();
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'is_wp_error',
 			[
 				'times'  => 1,
 				'return' => function ( $error ) {
-					return $error instanceof \WP_Error;
+					return $error instanceof WP_Error;
 				},
 			]
 		);
@@ -56,17 +57,17 @@ class MetaDataTest extends TestCase {
 	}
 
 	public function test_add_watermark_metadata_bails_out_on_get_post_meta() {
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'is_wp_error',
 			[
 				'times'  => 1,
 				'return' => function ( $error ) {
-					return $error instanceof \WP_Error;
+					return $error instanceof WP_Error;
 				},
 			]
 		);
 
-		\WP_Mock::userFunction( 'get_post_meta' )
+		WP_Mock::userFunction( 'get_post_meta' )
 			->with( 1, 'watermark_my_images', true )
 			->andReturn(
 				[
@@ -86,21 +87,21 @@ class MetaDataTest extends TestCase {
 			'rel' => 'https://www.example.com/wp-content/uploads/2024/10/img-watermark-my-images.jpg',
 		];
 
-		\WP_Mock::userFunction(
+		WP_Mock::userFunction(
 			'is_wp_error',
 			[
 				'times'  => 1,
 				'return' => function ( $error ) {
-					return $error instanceof \WP_Error;
+					return $error instanceof WP_Error;
 				},
 			]
 		);
 
-		\WP_Mock::userFunction( 'get_post_meta' )
+		WP_Mock::userFunction( 'get_post_meta' )
 			->with( 1, 'watermark_my_images', true )
 			->andReturn( '' );
 
-		\WP_Mock::userFunction( 'update_post_meta' )
+		WP_Mock::userFunction( 'update_post_meta' )
 			->with( 1, 'watermark_my_images', $watermark )
 			->andReturn( true );
 

--- a/tests/Services/PageLoadTest.php
+++ b/tests/Services/PageLoadTest.php
@@ -2,11 +2,10 @@
 
 namespace WatermarkMyImages\Tests\Services;
 
+use WP_Mock;
 use Mockery;
 use DOMDocument;
 use WP_Mock\Tools\TestCase;
-use WatermarkMyImages\Abstracts\Service;
-use WatermarkMyImages\Engine\Watermarker;
 use WatermarkMyImages\Services\PageLoad;
 
 /**
@@ -21,7 +20,7 @@ class PageLoadTest extends TestCase {
 	public PageLoad $page_load;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->page_load = new PageLoad();
 
@@ -29,13 +28,13 @@ class PageLoadTest extends TestCase {
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 
 		$this->destroy_mock_image( __DIR__ . '/sample.png' );
 	}
 
 	public function test_register() {
-		\WP_Mock::expectFilterAdded( 'wp_get_attachment_image', [ $this->page_load, 'register_wp_get_attachment_image' ], 10, 5 );
+		WP_Mock::expectFilterAdded( 'wp_get_attachment_image', [ $this->page_load, 'register_wp_get_attachment_image' ], 10, 5 );
 
 		$this->page_load->register();
 
@@ -56,7 +55,7 @@ class PageLoadTest extends TestCase {
 	}
 
 	public function test_register_wp_get_attachment_image_bails_out_if_options_is_not_enabled() {
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->once()
 			->with( 'watermark_my_images', [] )
 			->andReturn(
@@ -81,7 +80,7 @@ class PageLoadTest extends TestCase {
 		$page_load = Mockery::mock( PageLoad::class )->makePartial();
 		$page_load->shouldAllowMockingProtectedMethods();
 
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->once()
 			->with( 'watermark_my_images', [] )
 			->andReturn(
@@ -98,7 +97,7 @@ class PageLoadTest extends TestCase {
 				}
 			);
 
-		\WP_Mock::expectFilter(
+		WP_Mock::expectFilter(
 			'watermark_my_images_attachment_html',
 			'<p><img src="https://example.com/wp-content/uploads/sample-watermark.jpeg"/></p>',
 			1
@@ -171,7 +170,7 @@ class PageLoadTest extends TestCase {
 			)
 			->andReturnUsing(
 				function ( $arg1, $arg2, $arg3 ) {
-					$dom = new \DOMDocument();
+					$dom = new DOMDocument();
 					$dom->loadHTML( $arg2, LIBXML_NOERROR );
 					$srcset_img = $dom->getElementsByTagName( 'img' )[0];
 

--- a/tests/Services/WooCommerceTest.php
+++ b/tests/Services/WooCommerceTest.php
@@ -2,10 +2,10 @@
 
 namespace WatermarkMyImages\Tests\Services;
 
+use WP_Mock;
 use Mockery;
-use DOMDocument;
+use WC_Product;
 use WP_Mock\Tools\TestCase;
-use WatermarkMyImages\Abstracts\Service;
 use WatermarkMyImages\Engine\Watermarker;
 use WatermarkMyImages\Services\WooCommerce;
 
@@ -21,7 +21,7 @@ class WooCommerceTest extends TestCase {
 	public WooCommerce $woocommerce;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		WP_Mock::setUp();
 
 		$this->woocommerce = new WooCommerce();
 
@@ -29,14 +29,14 @@ class WooCommerceTest extends TestCase {
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		WP_Mock::tearDown();
 
 		$this->destroy_mock_image( __DIR__ . '/sample.png' );
 	}
 
 	public function test_register() {
-		\WP_Mock::expectFilterAdded( 'woocommerce_product_get_image', [ $this->woocommerce, 'add_watermark_on_get_image' ], 10, 5 );
-		\WP_Mock::expectFilterAdded( 'woocommerce_single_product_image_thumbnail_html', [ $this->woocommerce, 'add_watermark_to_product_gallery_image' ], 10, 2 );
+		WP_Mock::expectFilterAdded( 'woocommerce_product_get_image', [ $this->woocommerce, 'add_watermark_on_get_image' ], 10, 5 );
+		WP_Mock::expectFilterAdded( 'woocommerce_single_product_image_thumbnail_html', [ $this->woocommerce, 'add_watermark_to_product_gallery_image' ], 10, 2 );
 
 		$this->woocommerce->register();
 
@@ -44,10 +44,10 @@ class WooCommerceTest extends TestCase {
 	}
 
 	public function test_add_watermark_on_get_image_bails_on_image_existence() {
-		$product = Mockery::mock( \WC_Product::class )->makePartial();
+		$product = Mockery::mock( WC_Product::class )->makePartial();
 		$product->shouldAllowMockingProtectedMethods();
 
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->once()
 			->with( 'watermark_my_images', [] )
 			->andReturn(
@@ -81,10 +81,10 @@ class WooCommerceTest extends TestCase {
 	}
 
 	public function test_add_watermark_on_get_image_passes() {
-		$product = Mockery::mock( \WC_Product::class )->makePartial();
+		$product = Mockery::mock( WC_Product::class )->makePartial();
 		$product->shouldAllowMockingProtectedMethods();
 
-		\WP_Mock::userFunction( 'get_option' )
+		WP_Mock::userFunction( 'get_option' )
 			->once()
 			->with( 'watermark_my_images', [] )
 			->andReturn(
@@ -111,12 +111,12 @@ class WooCommerceTest extends TestCase {
 
 		$this->woocommerce->watermarker = $watermarker;
 
-		\WP_Mock::userFunction( 'get_post_meta' )
+		WP_Mock::userFunction( 'get_post_meta' )
 			->once()
 			->with( 1, 'watermark_my_images', true )
 			->andReturn( '' );
 
-		\WP_Mock::expectAction(
+		WP_Mock::expectAction(
 			'watermark_my_images_on_woo_product_get_image',
 			'https://example.com/wp-content/uploads/2024/10/sample-1-watermark-my-images.jpg',
 			$watermark,


### PR DESCRIPTION
This PR resolves [WP-244](https://appworld.atlassian.net/browse/WP-244)

## Description / Background Context

At the moment, we are using fully qualified class path like so `\WP_Mock` we intend to replace them with their `use` counter part.

## Testing Instructions

- Pull PR to local.
- Run `composer install` .
- Then run `composer run test`.
- Observe that all test case passes like in the screenshot below.

## Screenshots / Screencast

<img width="863" height="418" alt="Screenshot 2026-06-11 223026" src="https://github.com/user-attachments/assets/3076a18c-769e-4301-a91a-031344cab98c" />
