### PR TITLE
Refactor: Php unit tests use wp-mock-tc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.3.0
 * Feat: Add `More Plugins` options page.
 * Refactor: Replaced fully qualified path with their use counter part.
+* Refactor: Php unit tests now uses wp-mock-tc library.
 
 ## 1.2.0
 * Chore: Update CI/CD pipeline.

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
   ],
   "require": {
     "imagine/imagine": "^1.3",
-    "badasswp/pluginate": "^1.0"
+    "badasswp/pluginate": "^1.0",
+    "badasswp/wp-mock-tc": "^1.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.6",

--- a/inc/Admin/Form.php
+++ b/inc/Admin/Form.php
@@ -88,8 +88,9 @@ class Form {
 	 * @return string
 	 */
 	protected function get_form_action(): string {
-		$uri = sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) );
-		return esc_url( untrailingslashit( $uri ) );
+		return esc_url(
+			sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) )
+		);
 	}
 
 	/**

--- a/inc/Admin/Form.php
+++ b/inc/Admin/Form.php
@@ -88,9 +88,6 @@ class Form {
 	 * @return string
 	 */
 	protected function get_form_action(): string {
-		// return esc_url(
-		//  sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) )
-		// );
 		$uri = sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) );
 		return esc_url( untrailingslashit( $uri ) );
 	}

--- a/inc/Admin/Form.php
+++ b/inc/Admin/Form.php
@@ -88,9 +88,11 @@ class Form {
 	 * @return string
 	 */
 	protected function get_form_action(): string {
-		return esc_url(
-			sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) )
-		);
+		// return esc_url(
+		//  sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) )
+		// );
+		$uri = sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) );
+		return esc_url( untrailingslashit( $uri ) );
 	}
 
 	/**

--- a/tests/Admin/FormTest.php
+++ b/tests/Admin/FormTest.php
@@ -138,7 +138,7 @@ class FormTest extends WPMockTestCase {
 
 		$form_action = $this->form->get_form_action();
 
-		$this->assertSame( 'https://example.com', $form_action );
+		$this->assertSame( 'https://example.com/', $form_action );
 	}
 
 	public function test_get_form_main() {

--- a/tests/Admin/FormTest.php
+++ b/tests/Admin/FormTest.php
@@ -3,8 +3,8 @@
 namespace WatermarkMyImages\Tests\Admin;
 
 use Mockery;
-use WP_Mock\Tools\TestCase;
 use WatermarkMyImages\Admin\Form;
+use Badasswp\WPMockTC\WPMockTestCase;
 
 /**
  * @covers \WatermarkMyImages\Admin\Form::__construct
@@ -22,11 +22,11 @@ use WatermarkMyImages\Admin\Form;
  * @covers \WatermarkMyImages\Admin\Form::get_form_submit
  * @covers \WatermarkMyImages\Admin\Form::get_form_notice
  */
-class FormTest extends TestCase {
+class FormTest extends WPMockTestCase {
 	public Form $form;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		parent::setUp();
 
 		$this->form = Mockery::mock( Form::class )->makePartial();
 		$this->form->shouldAllowMockingProtectedMethods();
@@ -67,7 +67,7 @@ class FormTest extends TestCase {
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		parent::tearDown();
 	}
 
 	public function test_get_options() {
@@ -112,13 +112,6 @@ class FormTest extends TestCase {
 	public function test_get_form_action() {
 		$_SERVER['REQUEST_URI'] = 'https://example.com/\/';
 
-		\WP_Mock::userFunction( 'esc_url' )
-			->andReturnUsing(
-				function ( $arg ) {
-					return rtrim( filter_var( $arg, FILTER_SANITIZE_URL ), '/' );
-				}
-			);
-
 		\WP_Mock::userFunction( 'sanitize_text_field' )
 			->andReturnUsing(
 				function ( $arg ) {
@@ -130,6 +123,13 @@ class FormTest extends TestCase {
 			->andReturnUsing(
 				function ( $arg ) {
 					return stripslashes( $arg );
+				}
+			);
+
+		\WP_Mock::userFunction( 'untrailingslashit' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return rtrim( $arg, '/' );
 				}
 			);
 

--- a/tests/Admin/FormTest.php
+++ b/tests/Admin/FormTest.php
@@ -113,19 +113,12 @@ class FormTest extends WPMockTestCase {
 	}
 
 	public function test_get_form_action() {
-		$_SERVER['REQUEST_URI'] = 'https://example.com/\/';
-
-		WP_Mock::userFunction( 'esc_url' )
-			->andReturnUsing(
-				function ( $arg ) {
-					return $arg;
-				}
-			);
+		$_SERVER['REQUEST_URI'] = 'https://example.com/';
 
 		WP_Mock::userFunction( 'sanitize_text_field' )
 			->andReturnUsing(
 				function ( $arg ) {
-					return stripslashes( $arg );
+					return $arg;
 				}
 			);
 
@@ -138,7 +131,7 @@ class FormTest extends WPMockTestCase {
 
 		$form_action = $this->form->get_form_action();
 
-		$this->assertSame( 'https://example.com/', $form_action );
+		$this->assertSame( 'https://example.com', $form_action );
 	}
 
 	public function test_get_form_main() {

--- a/tests/Admin/OptionsTest.php
+++ b/tests/Admin/OptionsTest.php
@@ -3,8 +3,8 @@
 namespace WatermarkMyImages\Tests\Admin;
 
 use Mockery;
-use WP_Mock\Tools\TestCase;
 use WatermarkMyImages\Admin\Options;
+use Badasswp\WPMockTC\WPMockTestCase;
 
 /**
  * @covers \WatermarkMyImages\Admin\Options::get_form_page
@@ -12,25 +12,16 @@ use WatermarkMyImages\Admin\Options;
  * @covers \WatermarkMyImages\Admin\Options::get_form_notice
  * @covers \WatermarkMyImages\Admin\Options::get_form_fields
  */
-class OptionsTest extends TestCase {
+class OptionsTest extends WPMockTestCase {
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		parent::setUp();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		parent::tearDown();
 	}
 
 	public function test_get_form_page() {
-		\WP_Mock::userFunction(
-			'esc_html__',
-			[
-				'times'  => 2,
-				'return' => function ( $text, $domain = 'watermark-my-images' ) {
-					return $text;
-				},
-			]
-		);
 
 		$form_page = Options::get_form_page();
 
@@ -46,15 +37,6 @@ class OptionsTest extends TestCase {
 	}
 
 	public function test_get_form_submit() {
-		\WP_Mock::userFunction(
-			'esc_html__',
-			[
-				'times'  => 2,
-				'return' => function ( $text, $domain = 'watermark-my-images' ) {
-					return $text;
-				},
-			]
-		);
 
 		$form_submit = Options::get_form_submit();
 
@@ -75,35 +57,6 @@ class OptionsTest extends TestCase {
 	}
 
 	public function test_get_form_fields() {
-		\WP_Mock::userFunction(
-			'esc_html__',
-			[
-				'times'  => 22,
-				'return' => function ( $text, $domain = 'watermark-my-images' ) {
-					return $text;
-				},
-			]
-		);
-
-		\WP_Mock::userFunction(
-			'esc_attr',
-			[
-				'times'  => 10,
-				'return' => function ( $text, $domain = 'watermark-my-images' ) {
-					return $text;
-				},
-			]
-		);
-
-		\WP_Mock::userFunction(
-			'esc_attr__',
-			[
-				'times'  => 6,
-				'return' => function ( $text, $domain = 'watermark-my-images' ) {
-					return $text;
-				},
-			]
-		);
 
 		$form_fields = Options::get_form_fields();
 
@@ -181,15 +134,6 @@ class OptionsTest extends TestCase {
 	}
 
 	public function test_get_form_notice() {
-		\WP_Mock::userFunction(
-			'esc_html__',
-			[
-				'times'  => 1,
-				'return' => function ( $text, $domain = 'watermark-my-images' ) {
-					return $text;
-				},
-			]
-		);
 
 		$form_notice = Options::get_form_notice();
 

--- a/tests/Engine/ImageTest.php
+++ b/tests/Engine/ImageTest.php
@@ -4,7 +4,7 @@ namespace WatermarkMyImages\Tests\Engine;
 
 use Mockery;
 use Exception;
-use WP_Mock\Tools\TestCase;
+use Badasswp\WPMockTC\WPMockTestCase;
 
 use WatermarkMyImages\Engine\Image;
 use WatermarkMyImages\Engine\Watermarker;
@@ -16,17 +16,17 @@ use Imagine\Image\ImageInterface as Image_Object;
  * @covers \WatermarkMyImages\Engine\Image::get_image
  * @covers \WatermarkMyImages\Engine\Image::get_imagine
  */
-class ImageTest extends TestCase {
+class ImageTest extends WPMockTestCase {
 	public Image $image;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		parent::setUp();
 
 		Watermarker::$file = __DIR__ . '/sample.png';
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		parent::tearDown();
 	}
 
 	public function test_get_image_passes_and_returns_image_object() {
@@ -69,20 +69,6 @@ class ImageTest extends TestCase {
 		$image->shouldReceive( 'get_imagine' )
 			->with( Mockery::type( Imagine::class ) )
 			->andReturn( $imagine );
-
-		\WP_Mock::userFunction( 'esc_html__' )
-			->andReturnUsing(
-				function ( $arg ) {
-					return $arg;
-				}
-			);
-
-		\WP_Mock::userFunction( 'esc_html' )
-			->andReturnUsing(
-				function ( $arg ) {
-					return $arg;
-				}
-			);
 
 		$this->expectException( Exception::class );
 		$this->expectExceptionMessage( 'Unable to open Image Resource, File not found' );

--- a/tests/Engine/TextTest.php
+++ b/tests/Engine/TextTest.php
@@ -5,7 +5,7 @@ namespace WatermarkMyImages\Tests\Engine;
 use Mockery;
 use Exception;
 use ReflectionClass;
-use WP_Mock\Tools\TestCase;
+use Badasswp\WPMockTC\WPMockTestCase;
 
 use WatermarkMyImages\Engine\Text;
 use WatermarkMyImages\Engine\Watermarker;
@@ -32,18 +32,18 @@ use Imagine\Image\Palette\Color\ColorInterface;
  * @covers \WatermarkMyImages\Engine\Text::get_text_length
  * @covers \WatermarkMyImages\Engine\Text::get_text
  */
-class TextTest extends TestCase {
+class TextTest extends WPMockTestCase {
 	public Text $text;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		parent::setUp();
 
 		$this->text        = new Text();
 		Watermarker::$file = __DIR__ . '/sample.png';
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		parent::tearDown();
 	}
 
 	public function test_args_is_set() {
@@ -101,16 +101,6 @@ class TextTest extends TestCase {
 			->with( 'watermark_my_images', [] )
 			->andReturn( $options );
 
-		\WP_Mock::userFunction(
-			'wp_parse_args',
-			[
-				'times'  => 1,
-				'return' => function ( $args, $default_args ) {
-					return array_merge( $default_args, $args );
-				},
-			]
-		);
-
 		$text->shouldReceive( 'get_size' )
 			->with( $options )
 			->andReturn( 60 );
@@ -151,16 +141,6 @@ class TextTest extends TestCase {
 		\WP_Mock::userFunction( 'get_option' )
 			->with( 'watermark_my_images', [] )
 			->andReturn( $options );
-
-		\WP_Mock::userFunction(
-			'wp_parse_args',
-			[
-				'times'  => 1,
-				'return' => function ( $args, $default_args ) {
-					return array_merge( $default_args, $args );
-				},
-			]
-		);
 
 		$text->shouldReceive( 'get_size' )
 			->with( $options )
@@ -222,16 +202,6 @@ class TextTest extends TestCase {
 		\WP_Mock::userFunction( 'get_option' )
 			->with( 'watermark_my_images', [] )
 			->andReturn( $options );
-
-		\WP_Mock::userFunction(
-			'wp_parse_args',
-			[
-				'times'  => 1,
-				'return' => function ( $args, $default_args ) {
-					return array_merge( $default_args, $args );
-				},
-			]
-		);
 
 		\WP_Mock::onFilter( 'watermark_my_images_text' )
 			->with( $options )
@@ -322,20 +292,6 @@ class TextTest extends TestCase {
 				new \Exception( 'Error: Unable to parse RGB color' )
 			);
 
-		\WP_Mock::userFunction( 'esc_html__' )
-			->andReturnUsing(
-				function ( $arg ) {
-					return $arg;
-				}
-			);
-
-		\WP_Mock::userFunction( 'esc_html' )
-			->andReturnUsing(
-				function ( $arg ) {
-					return $arg;
-				}
-			);
-
 		$this->expectException( Exception::class );
 		$this->expectExceptionMessage( 'Unable to create Text color, Error: Unable to parse RGB color' );
 
@@ -369,20 +325,6 @@ class TextTest extends TestCase {
 				new \Exception( 'Error: Unable to parse Background color' )
 			);
 
-		\WP_Mock::userFunction( 'esc_html__' )
-			->andReturnUsing(
-				function ( $arg ) {
-					return $arg;
-				}
-			);
-
-		\WP_Mock::userFunction( 'esc_html' )
-			->andReturnUsing(
-				function ( $arg ) {
-					return $arg;
-				}
-			);
-
 		$this->expectException( Exception::class );
 		$this->expectExceptionMessage( 'Unable to create Background color, Error: Unable to parse Background color' );
 
@@ -390,177 +332,6 @@ class TextTest extends TestCase {
 
 		$this->assertConditionsMet();
 	}
-
-	/*public function test_get_text_catches_textbox_exception_and_throws_it() {
-		$text = Mockery::mock( Text::class )->makePartial();
-		$text->shouldAllowMockingProtectedMethods();
-
-		$rgb = Mockery::mock( RGB::class )->makePartial();
-		$rgb->shouldAllowMockingProtectedMethods();
-
-		$imagine = Mockery::mock( Imagine::class )->makePartial();
-		$imagine->shouldAllowMockingProtectedMethods();
-
-		\WP_Mock::userFunction( 'esc_html__' )
-			->andReturnUsing(
-				function ( $arg ) {
-					return $arg;
-				}
-			);
-
-		\WP_Mock::userFunction( 'esc_html' )
-			->andReturnUsing(
-				function ( $arg ) {
-					return $arg;
-				}
-			);
-
-		$bg_color = new TextColor( $rgb, [ 255, 255, 255 ], 100 );
-
-		// Now, 1st stage...
-		$text->shouldReceive( 'get_rgb' )
-			->with( Mockery::type( RGB::class ) )
-			->andReturn( $rgb );
-
-		$text->shouldReceive( 'get_option' )
-			->with( 'bg_color' )
-			->andReturn( '#FFF' );
-
-		$text->shouldReceive( 'get_option' )
-			->with( 'bg_opacity' )
-			->andReturn( 100 );
-
-		$rgb->shouldReceive( 'color' )
-			->with( '#FFF', 100 )
-			->andReturn( $bg_color );
-
-		// Now, 2nd stage...
-		$text->shouldReceive( 'get_imagine' )
-			->with( Mockery::type( Imagine::class ) )
-			->andReturn( $imagine );
-
-		$box = new Box( 100, 200 );
-
-		$text->shouldReceive( 'get_text_box' )
-			->andReturn( $box );
-
-		$imagine->shouldReceive( 'create' )
-			->with( $box, $bg_color )
-			->andThrow(
-				new \Exception( 'Error: Text Box color' )
-			);
-
-		$this->expectException( \Error::class );
-		$this->expectExceptionMessage( 'Unable to create Text Box, Error: Text Box color' );
-
-		$text->get_text();
-
-		$this->assertConditionsMet();
-	}
-
-	public function test_get_text_catches_draw_exception_and_throws_it() {
-		$text = Mockery::mock( Text::class )->makePartial();
-		$text->shouldAllowMockingProtectedMethods();
-
-		$rgb = Mockery::mock( RGB::class )->makePartial();
-		$rgb->shouldAllowMockingProtectedMethods();
-
-		$box = Mockery::mock( Box::class )->makePartial();
-		$box->shouldAllowMockingProtectedMethods();
-
-		$imagine = Mockery::mock( Imagine::class )->makePartial();
-		$imagine->shouldAllowMockingProtectedMethods();
-
-		$font = Mockery::mock( FontInterface::class )->makePartial();
-		$font->shouldAllowMockingProtectedMethods();
-
-		$bg_color = Mockery::mock( ColorInterface::class )->makePartial();
-		$bg_color->shouldAllowMockingProtectedMethods();
-
-		$text_box = Mockery::mock( ImageInterface::class )->makePartial();
-		$text_box->shouldAllowMockingProtectedMethods();
-
-		$drawer = Mockery::mock( DrawerInterface::class )->makePartial();
-		$drawer->shouldAllowMockingProtectedMethods();
-
-		\WP_Mock::userFunction( 'esc_html__' )
-			->andReturnUsing(
-				function ( $arg ) {
-					return $arg;
-				}
-			);
-
-		\WP_Mock::userFunction( 'esc_html' )
-			->andReturnUsing(
-				function ( $arg ) {
-					return $arg;
-				}
-			);
-
-		// Now, 1st stage...
-		$text->shouldReceive( 'get_rgb' )
-			->with( Mockery::type( RGB::class ) )
-			->andReturn( $rgb );
-
-		$text->shouldReceive( 'get_option' )
-			->with( 'bg_color' )
-			->andReturn( '#FFF' );
-
-		$text->shouldReceive( 'get_option' )
-			->with( 'bg_opacity' )
-			->andReturn( '100' );
-
-		$rgb->shouldReceive( 'color' )
-			->with( '#FFF', '100' )
-			->andReturn( $bg_color );
-
-		// Now, 2nd stage...
-		$text->shouldReceive( 'get_imagine' )
-			->with( Mockery::type( Imagine::class ) )
-			->andReturn( $imagine );
-
-		$text->shouldReceive( 'get_text_length' )
-			->andReturn( '200' );
-
-		$text->shouldReceive( 'get_text_box' )
-			->andReturn( $box );
-
-		$text->shouldReceive( 'get_option' )
-			->with( 'size' )
-			->andReturn( '100' );
-
-		$imagine->shouldReceive( 'create' )
-			->with( $box, $bg_color )
-			->andReturn( $text_box );
-
-		// Now, 3rd stage...
-		$text_box->shouldReceive( 'draw' )
-			->andReturn( $drawer );
-
-		$text->shouldReceive( 'get_option' )
-			->with( 'label' )
-			->andReturn( 'WATERMARK' );
-
-		$text->shouldReceive( 'get_font' )
-			->andReturn( $font );
-
-		$drawer->shouldReceive( 'text' )
-			->with(
-				'WATERMARK',
-				$font,
-				Mockery::type( PointInterface::class )
-			)
-			->andThrow(
-				new \Exception( 'Error: Drawing is disabled..' )
-			);
-
-		$this->expectException( Exception::class );
-		$this->expectExceptionMessage( '' );
-
-		$text->get_text();
-
-		$this->assertConditionsMet();
-	}*/
 
 	public function test_get_font_url() {
 		$text = Mockery::mock( Text::class )->makePartial();

--- a/tests/Engine/TextTest.php
+++ b/tests/Engine/TextTest.php
@@ -334,6 +334,177 @@ class TextTest extends WPMockTestCase {
 		$this->assertConditionsMet();
 	}
 
+	/*public function test_get_text_catches_textbox_exception_and_throws_it() {
+		$text = Mockery::mock( Text::class )->makePartial();
+		$text->shouldAllowMockingProtectedMethods();
+
+		$rgb = Mockery::mock( RGB::class )->makePartial();
+		$rgb->shouldAllowMockingProtectedMethods();
+
+		$imagine = Mockery::mock( Imagine::class )->makePartial();
+		$imagine->shouldAllowMockingProtectedMethods();
+
+		\WP_Mock::userFunction( 'esc_html__' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( 'esc_html' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		$bg_color = new TextColor( $rgb, [ 255, 255, 255 ], 100 );
+
+		// Now, 1st stage...
+		$text->shouldReceive( 'get_rgb' )
+			->with( Mockery::type( RGB::class ) )
+			->andReturn( $rgb );
+
+		$text->shouldReceive( 'get_option' )
+			->with( 'bg_color' )
+			->andReturn( '#FFF' );
+
+		$text->shouldReceive( 'get_option' )
+			->with( 'bg_opacity' )
+			->andReturn( 100 );
+
+		$rgb->shouldReceive( 'color' )
+			->with( '#FFF', 100 )
+			->andReturn( $bg_color );
+
+		// Now, 2nd stage...
+		$text->shouldReceive( 'get_imagine' )
+			->with( Mockery::type( Imagine::class ) )
+			->andReturn( $imagine );
+
+		$box = new Box( 100, 200 );
+
+		$text->shouldReceive( 'get_text_box' )
+			->andReturn( $box );
+
+		$imagine->shouldReceive( 'create' )
+			->with( $box, $bg_color )
+			->andThrow(
+				new \Exception( 'Error: Text Box color' )
+			);
+
+		$this->expectException( \Error::class );
+		$this->expectExceptionMessage( 'Unable to create Text Box, Error: Text Box color' );
+
+		$text->get_text();
+
+		$this->assertConditionsMet();
+	}
+
+	public function test_get_text_catches_draw_exception_and_throws_it() {
+		$text = Mockery::mock( Text::class )->makePartial();
+		$text->shouldAllowMockingProtectedMethods();
+
+		$rgb = Mockery::mock( RGB::class )->makePartial();
+		$rgb->shouldAllowMockingProtectedMethods();
+
+		$box = Mockery::mock( Box::class )->makePartial();
+		$box->shouldAllowMockingProtectedMethods();
+
+		$imagine = Mockery::mock( Imagine::class )->makePartial();
+		$imagine->shouldAllowMockingProtectedMethods();
+
+		$font = Mockery::mock( FontInterface::class )->makePartial();
+		$font->shouldAllowMockingProtectedMethods();
+
+		$bg_color = Mockery::mock( ColorInterface::class )->makePartial();
+		$bg_color->shouldAllowMockingProtectedMethods();
+
+		$text_box = Mockery::mock( ImageInterface::class )->makePartial();
+		$text_box->shouldAllowMockingProtectedMethods();
+
+		$drawer = Mockery::mock( DrawerInterface::class )->makePartial();
+		$drawer->shouldAllowMockingProtectedMethods();
+
+		\WP_Mock::userFunction( 'esc_html__' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( 'esc_html' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		// Now, 1st stage...
+		$text->shouldReceive( 'get_rgb' )
+			->with( Mockery::type( RGB::class ) )
+			->andReturn( $rgb );
+
+		$text->shouldReceive( 'get_option' )
+			->with( 'bg_color' )
+			->andReturn( '#FFF' );
+
+		$text->shouldReceive( 'get_option' )
+			->with( 'bg_opacity' )
+			->andReturn( '100' );
+
+		$rgb->shouldReceive( 'color' )
+			->with( '#FFF', '100' )
+			->andReturn( $bg_color );
+
+		// Now, 2nd stage...
+		$text->shouldReceive( 'get_imagine' )
+			->with( Mockery::type( Imagine::class ) )
+			->andReturn( $imagine );
+
+		$text->shouldReceive( 'get_text_length' )
+			->andReturn( '200' );
+
+		$text->shouldReceive( 'get_text_box' )
+			->andReturn( $box );
+
+		$text->shouldReceive( 'get_option' )
+			->with( 'size' )
+			->andReturn( '100' );
+
+		$imagine->shouldReceive( 'create' )
+			->with( $box, $bg_color )
+			->andReturn( $text_box );
+
+		// Now, 3rd stage...
+		$text_box->shouldReceive( 'draw' )
+			->andReturn( $drawer );
+
+		$text->shouldReceive( 'get_option' )
+			->with( 'label' )
+			->andReturn( 'WATERMARK' );
+
+		$text->shouldReceive( 'get_font' )
+			->andReturn( $font );
+
+		$drawer->shouldReceive( 'text' )
+			->with(
+				'WATERMARK',
+				$font,
+				Mockery::type( PointInterface::class )
+			)
+			->andThrow(
+				new \Exception( 'Error: Drawing is disabled..' )
+			);
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( '' );
+
+		$text->get_text();
+
+		$this->assertConditionsMet();
+	}*/
+
 	public function test_get_font_url() {
 		$text = Mockery::mock( Text::class )->makePartial();
 		$text->shouldAllowMockingProtectedMethods();

--- a/tests/Services/AdminTest.php
+++ b/tests/Services/AdminTest.php
@@ -3,11 +3,11 @@
 namespace WatermarkMyImages\Tests\Services;
 
 use Mockery;
-use WP_Mock\Tools\TestCase;
 use WatermarkMyImages\Admin\Form;
 use WatermarkMyImages\Admin\Options;
 use WatermarkMyImages\Services\Admin;
 use WatermarkMyImages\Abstracts\Service;
+use Badasswp\WPMockTC\WPMockTestCase;
 
 /**
  * @covers \WatermarkMyImages\Services\Admin::__construct
@@ -24,17 +24,17 @@ use WatermarkMyImages\Abstracts\Service;
  * @covers \WatermarkMyImages\Admin\Options::init
  * @covers \WatermarkMyImages\Services\Admin::__construct
  */
-class AdminTest extends TestCase {
+class AdminTest extends WPMockTestCase {
 	public Admin $admin;
 
 	public function setUp(): void {
-		\WP_Mock::setUp();
+		parent::setup();
 
 		$this->admin = new Admin();
 	}
 
 	public function tearDown(): void {
-		\WP_Mock::tearDown();
+		parent::tearDown();
 
 		$_POST = [];
 	}
@@ -51,35 +51,6 @@ class AdminTest extends TestCase {
 	}
 
 	public function test_register_options_menu() {
-		\WP_Mock::userFunction(
-			'esc_html__',
-			[
-				'times'  => 135,
-				'return' => function ( $text, $domain = 'watermark-my-images' ) {
-					return $text;
-				},
-			]
-		);
-
-		\WP_Mock::userFunction(
-			'esc_attr',
-			[
-				'times'  => 50,
-				'return' => function ( $text ) {
-					return $text;
-				},
-			]
-		);
-
-		\WP_Mock::userFunction(
-			'esc_attr__',
-			[
-				'times'  => 30,
-				'return' => function ( $text ) {
-					return $text;
-				},
-			]
-		);
 
 		\WP_Mock::userFunction( 'add_menu_page' )
 			->with(
@@ -112,72 +83,15 @@ class AdminTest extends TestCase {
 		$this->assertConditionsMet();
 	}
 
-	public function test_register_options_init_bails_on_POST() {
-		\WP_Mock::userFunction(
-			'esc_html__',
-			[
-				'times'  => 81,
-				'return' => function ( $text, $domain = 'watermark-my-images' ) {
-					return $text;
-				},
-			]
-		);
+	// public function test_register_options_init_bails_on_POST() {
 
-		\WP_Mock::userFunction(
-			'esc_attr',
-			[
-				'times'  => 30,
-				'return' => function ( $text ) {
-					return $text;
-				},
-			]
-		);
 
-		\WP_Mock::userFunction(
-			'esc_attr__',
-			[
-				'times'  => 18,
-				'return' => function ( $text ) {
-					return $text;
-				},
-			]
-		);
+	//  $this->admin->register_options_init();
 
-		$this->admin->register_options_init();
-
-		$this->assertConditionsMet();
-	}
+	//  $this->assertConditionsMet();
+	// }
 
 	public function test_register_options_init_bails_on_NONCE() {
-		\WP_Mock::userFunction(
-			'esc_html__',
-			[
-				'times'  => 81,
-				'return' => function ( $text, $domain = 'watermark-my-images' ) {
-					return $text;
-				},
-			]
-		);
-
-		\WP_Mock::userFunction(
-			'esc_attr',
-			[
-				'times'  => 30,
-				'return' => function ( $text ) {
-					return $text;
-				},
-			]
-		);
-
-		\WP_Mock::userFunction(
-			'esc_attr__',
-			[
-				'times'  => 18,
-				'return' => function ( $text ) {
-					return $text;
-				},
-			]
-		);
 
 		$_POST = [
 			'watermark_my_images_save_settings'  => true,
@@ -202,35 +116,6 @@ class AdminTest extends TestCase {
 	}
 
 	public function test_register_options_init_passes() {
-		\WP_Mock::userFunction(
-			'esc_html__',
-			[
-				'times'  => 135,
-				'return' => function ( $text, $domain = 'watermark-my-images' ) {
-					return $text;
-				},
-			]
-		);
-
-		\WP_Mock::userFunction(
-			'esc_attr',
-			[
-				'times'  => 50,
-				'return' => function ( $text ) {
-					return $text;
-				},
-			]
-		);
-
-		\WP_Mock::userFunction(
-			'esc_attr__',
-			[
-				'times'  => 30,
-				'return' => function ( $text ) {
-					return $text;
-				},
-			]
-		);
 
 		$_POST = [
 			'watermark_my_images_save_settings'  => true,
@@ -287,35 +172,6 @@ class AdminTest extends TestCase {
 	}
 
 	public function test_register_options_init_updates_POST_values_that_are_set() {
-		\WP_Mock::userFunction(
-			'esc_html__',
-			[
-				'times'  => 135,
-				'return' => function ( $text, $domain = 'watermark-my-images' ) {
-					return $text;
-				},
-			]
-		);
-
-		\WP_Mock::userFunction(
-			'esc_attr',
-			[
-				'times'  => 50,
-				'return' => function ( $text ) {
-					return $text;
-				},
-			]
-		);
-
-		\WP_Mock::userFunction(
-			'esc_attr__',
-			[
-				'times'  => 30,
-				'return' => function ( $text ) {
-					return $text;
-				},
-			]
-		);
 
 		$updated_options = [
 			'size'   => 60,
@@ -387,33 +243,6 @@ class AdminTest extends TestCase {
 
 		\WP_Mock::userFunction( 'get_current_screen' )
 			->andReturn( $screen );
-
-		\WP_Mock::userFunction(
-			'esc_html__',
-			[
-				'return' => function ( $text, $domain = 'watermark-my-images' ) {
-					return $text;
-				},
-			]
-		);
-
-		\WP_Mock::userFunction(
-			'esc_attr',
-			[
-				'return' => function ( $text ) {
-					return $text;
-				},
-			]
-		);
-
-		\WP_Mock::userFunction(
-			'esc_attr__',
-			[
-				'return' => function ( $text ) {
-					return $text;
-				},
-			]
-		);
 
 		\WP_Mock::userFunction( 'plugins_url' )
 			->with( 'watermark-my-images/styles.css' )

--- a/tests/Services/AdminTest.php
+++ b/tests/Services/AdminTest.php
@@ -2,6 +2,7 @@
 
 namespace WatermarkMyImages\Tests\Services;
 
+use WP_Mock;
 use Mockery;
 use WatermarkMyImages\Admin\Form;
 use WatermarkMyImages\Admin\Options;


### PR DESCRIPTION
This PR resolves [WP-245](https://appworld.atlassian.net/browse/WP-245).

## Description / Background Context

At the moment, we are mocking some basic WP esc functions. Let’s us the Composer package `badasswp/wp-mock-tc` to enable us mock basic WP functions easily across our tests.

## Testing Instructions

- Pull PR to local.
- Run `composer run test`.
- Observe that all unit test cases pass correctly.

## Screenshots / Screencast

<img width="860" height="413" alt="Screenshot 2026-06-12 104330" src="https://github.com/user-attachments/assets/4a2f118b-1403-48d2-be09-7cd310ad6082" />
